### PR TITLE
[#11] Reduce exhaustion and pre-update new character-type actors

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -1,5 +1,5 @@
 {
-  "DND5E.LongRestHint": "Take a long rest? You can roll hit dice beforehand to restore health, and receive one round of free healing equal to your largest hit die plus your Constitution modifier. You will recover half your maximum hit dice, your class resources, your limited use item charges, and all your spell slots.",
+  "DND5E.LongRestHint": "Take a long rest? You can roll hit dice beforehand to restore health, and receive one round of free healing equal to your largest hit die plus your Constitution modifier. You will recover half your maximum hit dice, your class resources, your limited use item charges, and all your spell slots. Your levels of exhaustion will be reduced by one.",
   "DND5E.RestL": "Long",
   "DND5E.RestS": "Short",
   "MYTHACRI.ActivationMayhem": "Mayhem Action",
@@ -22,7 +22,7 @@
   "MYTHACRI.FreeLongRestHeal": "Free Heal",
   "MYTHACRI.FullRest": "Full Rest",
   "MYTHACRI.FullRestFlavor": "Full Rest (24 hours)",
-  "MYTHACRI.FullRestHint": "Take a full rest? You will recover all your hit dice and resources.",
+  "MYTHACRI.FullRestHint": "Take a full rest? You will recover all your hit dice and resources, and your levels of exhaustion wil be reduced by up to three.",
   "MYTHACRI.FullRestResult": "{name} takes a full rest and recovers {health} Hit Points and {dice} Hit Dice.",
   "MYTHACRI.FullRestResultHitDice": "{name} takes a full rest and recovers {dice} Hit Dice.",
   "MYTHACRI.FullRestResultHitPoints": "{name} takes a full rest and recovers {health} Hit Points.",


### PR DESCRIPTION
When an actor takes a long rest, their exhaustion will be reduced by 1 (to a minimum of 0).
When an actor takes a full rest, their exhaustion will be reduced by 3 (to a minimum of 0).

The displayed text in Long and Full rest dialogs have been adjusted accordingly.

In addition, when a `character` type actor is created, the Special Traits fields are pre-filled unless they already contain `@attributes.exhaustion`. This string is appended, not overriding, in case anything else is already present.

Closes #11.