### PR TITLE
[#68] Implement 'pips' instead of an experience bar

### DIFF
--- a/scripts/modules/data/pips.mjs
+++ b/scripts/modules/data/pips.mjs
@@ -2,7 +2,16 @@ export class ExperiencePips {
   /** Initialize module. */
   static init() {
     ExperiencePips._expLevels();
+    Hooks.once("ready", ExperiencePips._enableExperience);
     Hooks.on("renderActorSheet5eCharacter", ExperiencePips._renderActorSheet);
+  }
+
+  /**
+   * Forcibly set the system setting to be disabled.
+   * @returns {Promise<Setting>}
+   */
+  static async _enableExperience() {
+    return game.settings.set("dnd5e", "disableExperienceTracking", false);
   }
 
   /**

--- a/scripts/modules/data/pips.mjs
+++ b/scripts/modules/data/pips.mjs
@@ -1,0 +1,47 @@
+export class ExperiencePips {
+  /** Initialize module. */
+  static init() {
+    ExperiencePips._expLevels();
+    Hooks.on("renderActorSheet5eCharacter", ExperiencePips._renderActorSheet);
+  }
+
+  /**
+   * Swap out the experience bar with ten spans, colored by progression.
+   * @param {ActorSheet5eCharacter} sheet
+   * @param {HTMLElement} html
+   */
+  static _renderActorSheet(sheet, [html]) {
+    const width = html.querySelector(".xpbar .bar").style.width;
+    const filled = Number(width.replace("%", "")) / 10;
+    const pips = Array.fromRange(10).reduce((acc, n) => {
+      const active = n < filled ? "active" : "";
+      return acc + `<span class="pip ${active}"></span>`;
+    }, "");
+    const div = document.createElement("DIV");
+    div.innerHTML = `<div class="xpbar">${pips}</div>`;
+    html.querySelector(".xpbar").replaceWith(div.firstElementChild);
+  }
+
+
+  /** Modify the experience level thresholds to multiples of 10. */
+  static _expLevels() {
+    CONFIG.DND5E.CHARACTER_EXP_LEVELS = Array.fromRange(20).map(n => 10 * n);
+  }
+
+  /**
+   * Award all player-owned character-type actors with 1 pip.
+   * @param {boolean} [assigned=false]      Whether to restrict to assigned actors.
+   * @returns {Promise<Actor5e[]>}          The updated actors.
+   */
+  static async grantPip(assigned = false) {
+    const updates = game.actors.reduce((acc, actor) => {
+      if (actor.type !== "character") return acc;
+      if (!actor.hasPlayerOwner) return acc;
+      if (assigned && !game.users.some(user => user.character === actor)) return acc;
+      const xp = actor.system.details.xp.value;
+      acc.push({_id: actor.id, "system.details.xp.value": xp + 1});
+      return acc;
+    }, []);
+    return Actor.implementation.updateDocuments(updates);
+  }
+}

--- a/scripts/modules/interface.mjs
+++ b/scripts/modules/interface.mjs
@@ -1,13 +1,15 @@
 import {Crafting} from "./data/crafting/base-crafting.mjs";
 import {Encounter} from "./data/encounter.mjs";
 import {Mayhem} from "./data/mayhem.mjs";
+import {ExperiencePips} from "./data/pips.mjs";
 
 export class PublicInterface {
   static init() {
     globalThis.mythacri = {
       mayhem: Mayhem,
       crafting: Crafting,
-      encounter: Encounter
+      encounter: Encounter,
+      experience: ExperiencePips
     };
   }
 }

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -6,6 +6,7 @@ import {Settings} from "./modules/data/settings.mjs";
 import {SystemConfig} from "./modules/system-config.mjs";
 import {Soundboard} from "./modules/applications/soundboard.mjs";
 import {Encounter} from "./modules/data/encounter.mjs";
+import {ExperiencePips} from "./modules/data/pips.mjs";
 
 Hooks.once("init", SystemConfig.init);
 Hooks.once("init", PublicInterface.init);
@@ -15,3 +16,4 @@ Hooks.once("init", Crafting.init);
 Hooks.once("init", Settings.init);
 Hooks.once("init", Soundboard.init);
 Hooks.once("init", Encounter.init);
+Hooks.once("init", ExperiencePips.init);

--- a/styles/mythacri.css
+++ b/styles/mythacri.css
@@ -4,7 +4,7 @@
 /*                                */
 /* ------------------------------ */
 .dnd5e.sheet.actor.character .alignment,
-.dnd5e.sheet.actor.character .experience
+.dnd5e.sheet.actor.character .experience,
 .dnd5e.sheet.actor.npc .legendary {
   display: none;
 }

--- a/styles/mythacri.css
+++ b/styles/mythacri.css
@@ -28,7 +28,37 @@
   border: none;
 }
 .dnd5e.sheet.actor.character .sheet-header .xpbar .pip.active {
-  background-color: rgb(199 0 255 / 80%);
+  background-color: rgb(36, 124, 255);
+}
+.dnd5e.sheet.actor.character .sheet-header .xpbar .pip.active:nth-child(1) {
+  filter: brightness(0.6);
+}
+.dnd5e.sheet.actor.character .sheet-header .xpbar .pip.active:nth-child(2) {
+  filter: brightness(0.7);
+}
+.dnd5e.sheet.actor.character .sheet-header .xpbar .pip.active:nth-child(3) {
+  filter: brightness(0.8);
+}
+.dnd5e.sheet.actor.character .sheet-header .xpbar .pip.active:nth-child(4) {
+  filter: brightness(0.9);
+}
+.dnd5e.sheet.actor.character .sheet-header .xpbar .pip.active:nth-child(5) {
+  filter: brightness(1.0);
+}
+.dnd5e.sheet.actor.character .sheet-header .xpbar .pip.active:nth-child(6) {
+  filter: brightness(1.1);
+}
+.dnd5e.sheet.actor.character .sheet-header .xpbar .pip.active:nth-child(7) {
+  filter: brightness(1.2);
+}
+.dnd5e.sheet.actor.character .sheet-header .xpbar .pip.active:nth-child(8) {
+  filter: brightness(1.3);
+}
+.dnd5e.sheet.actor.character .sheet-header .xpbar .pip.active:nth-child(9) {
+  filter: brightness(1.4);
+}
+.dnd5e.sheet.actor.character .sheet-header .xpbar .pip.active:nth-child(10) {
+  filter: brightness(1.5);
 }
 
 /* ------------------------------ */

--- a/styles/mythacri.css
+++ b/styles/mythacri.css
@@ -4,8 +4,31 @@
 /*                                */
 /* ------------------------------ */
 .dnd5e.sheet.actor.character .alignment,
-.dnd5e.sheet.actor.npc .legendary {
+.dnd5e.sheet.actor.npc .legendary,
+.dnd5e.sheet.actor.character .experience {
   display: none;
+}
+.dnd5e.sheet.actor.character .sheet-header .header-exp {
+  flex: 0 0 160px;
+}
+.dnd5e.sheet.actor.character .sheet-header .xpbar {
+  flex: 0 0 22px;
+  display: flex;
+  border-radius: 1em;
+  border: 2px inset;
+  overflow: hidden;
+}
+.dnd5e.sheet.actor.character .sheet-header .xpbar .pip {
+  flex: 1;
+  border-right: 2px groove black;
+  opacity: 70%;
+  margin: 1px 0;
+}
+.dnd5e.sheet.actor.character .sheet-header .xpbar .pip:last-child {
+  border: none;
+}
+.dnd5e.sheet.actor.character .sheet-header .xpbar .pip.active {
+  background-color: rgb(199 0 255 / 80%);
 }
 
 /* ------------------------------ */

--- a/styles/mythacri.css
+++ b/styles/mythacri.css
@@ -4,8 +4,8 @@
 /*                                */
 /* ------------------------------ */
 .dnd5e.sheet.actor.character .alignment,
-.dnd5e.sheet.actor.npc .legendary,
-.dnd5e.sheet.actor.character .experience {
+.dnd5e.sheet.actor.character .experience
+.dnd5e.sheet.actor.npc .legendary {
   display: none;
 }
 .dnd5e.sheet.actor.character .sheet-header .header-exp {


### PR DESCRIPTION
This changes the experience thresholds to be 10 exp per level. The actor sheet then has its experience bar replaced with a new UI element.

This feature does require that experience tracking is enabled in the system settings.

An async method, `mythacri.experience.grantPip` is found in the api. It accepts one parameter (default `false`).
- The method grants 1 pip (i.e., one experience point) to all player-owned `characters`. If the parameter is set to `true`, only actors that are specifically assigned as player characters will be granted a pip. Otherwise, all characters that are owned by a player will be granted one.

Closes #68