### PR TITLE
[#95] Remove all currencies, introduce 'marbles'

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -37,6 +37,8 @@
   "MYTHACRI.CraftingSectionSpirit": "Spirit Binding",
   "MYTHACRI.CraftingSectionSpiritHint": "Enable 'Spirit Binding' for this actor.",
   "MYTHACRI.CraftingUnavailable": "Unavailable Recipes",
+  "MYTHACRI.CurrencyAbbrMarbles": "Mrb",
+  "MYTHACRI.CurrencyMarbles": "Marbles",
   "MYTHACRI.EncounterContent": "Roll a d12 to help determine a random encounter. The GM will be rolling {amount}d12.",
   "MYTHACRI.EncounterGMRolls": "Game Master Rolls",
   "MYTHACRI.EncounterPromptUsers": "Prompt Players",

--- a/scripts/modules/system-config.mjs
+++ b/scripts/modules/system-config.mjs
@@ -137,8 +137,23 @@ export class SystemConfig {
   }
 
   static _currencies() {
-    // Remove electrum.
-    delete CONFIG.DND5E.currencies.ep;
+    // Remove all currencies, replacing them with 'marbles'.
+    foundry.utils.mergeObject(CONFIG.DND5E.currencies, {
+      "-=cp": null,
+      "-=sp": null,
+      "-=ep": null,
+      "-=gp": null,
+      "-=pp": null,
+      mrb: {
+        abbreviation: "MYTHACRI.CurrencyAbbrMarbles",
+        conversion: 1,
+        label: "MYTHACRI.CurrencyMarbles"
+      }
+    }, {performDeletions: true});
+
+    // Change currency weight (marbles weigh half as much as a coin).
+    CONFIG.DND5E.encumbrance.currencyPerWeight.imperial *= 2;
+    CONFIG.DND5E.encumbrance.currencyPerWeight.metric *= 2;
   }
 
   static _consumableTypes() {


### PR DESCRIPTION
This removes all standard currencies rather than just electrum, and then adds 'marbles' (abbreviation 'mrb').

The amount of "coins" that equal 1 lb has also been doubled (i.e., changed the weight of coins from 0.02 lbs to 0.01 lbs).

Closes #95.