### PR TITLE
[#102] Delete languages in nested config

### DIFF
--- a/scripts/modules/system-config.mjs
+++ b/scripts/modules/system-config.mjs
@@ -45,15 +45,12 @@ export class SystemConfig {
 
   static _languages() {
     foundry.utils.mergeObject(CONFIG.DND5E.languages, {
-      "-=orc": null, // delete 'orc'
-      "-=gith": null, // delete 'gith'
-      "-=gnoll": null, // delete 'gnoll'
-      "-=ignan": null, // delete 'ignan'
-      "-=terran": null, // delete 'terran'
-      "-=auran": null, // delete 'auran'
-      "-=aquan": null, // delete 'aquan'
       "-=druidic": null, // delete 'druidic'
-      "-=gnomish": null, // delete 'gnomish'
+      "exotic.children.-=gith": null, // delete 'gith'
+      "exotic.children.-=gnoll": null, // delete 'gnoll'
+      "exotic.children.primordial.-=children": null, // delete 'ignan, terran, auran, aquan'
+      "standard.children.-=gnomish": null, // delete 'gnomish'
+      "standard.children.-=orc": null // delete 'orc'
     }, {performDeletions: true});
   }
 


### PR DESCRIPTION
Closes #102.

Since each language (bar druidic and thieves cant) is nested, we need the full path.

This has the unfortunate side effect of tossing an error from the system when it attempts to prelocalize (which has been reported: `https://github.com/foundryvtt/dnd5e/issues/2643`), but there seems to be no consequence on our side from that.