### PR TITLE
[#123] Create resource populator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,14 @@ Accessed through any `character` type actor, the new async method `Actor5e#fullR
  */
 async fullRestDialog()
 ```
+
+### Resources
+Accessed through `mythacri.resource`.
+```js
+/**
+ * Factory method to create an instance of this application for several actors.
+ * @param {Actor5e|Actor5e[]} [actors]      An actor or array of actors.
+ * @returns {void}
+ */
+static create(actors = [])
+```

--- a/languages/en.json
+++ b/languages/en.json
@@ -214,5 +214,9 @@
   "MYTHACRI.WeaponPropertySuperheavy": "Superheavy",
   "MYTHACRI.WeaponPropertyTension": "Tension",
   "MYTHACRI.WeaponPropertyTwinshot": "Twinshot",
+  "MYTHACRI.ResourcePopulatorActive": "Active",
+  "MYTHACRI.ResourcePopulatorSave": "Save",
+  "MYTHACRI.ResourcePopulatorTitle": "Populate Loot List: {name}",
+  "MYTHACRI.ResourcePopulatorNoActors": "You must provide at least one valid actor.",
   "TYPES.Item.mythacri-scripts.recipe": "Recipe"
 }

--- a/languages/en.json
+++ b/languages/en.json
@@ -167,6 +167,10 @@
   "MYTHACRI.ResourceMonsterTeeth": "Teeth",
   "MYTHACRI.ResourceMonsterTentacle": "Tentacle",
   "MYTHACRI.ResourceMonsterTusk": "Tusk",
+  "MYTHACRI.ResourcePopulatorActive": "Active",
+  "MYTHACRI.ResourcePopulatorNoActors": "You must provide at least one valid actor.",
+  "MYTHACRI.ResourcePopulatorSave": "Save",
+  "MYTHACRI.ResourcePopulatorTitle": "Populate Loot List: {name}",
   "MYTHACRI.ResourceTypeEssence": "Essence",
   "MYTHACRI.ResourceTypeGem": "Gem",
   "MYTHACRI.ResourceTypeLabelEssence": "{subtype} {type}",
@@ -214,9 +218,5 @@
   "MYTHACRI.WeaponPropertySuperheavy": "Superheavy",
   "MYTHACRI.WeaponPropertyTension": "Tension",
   "MYTHACRI.WeaponPropertyTwinshot": "Twinshot",
-  "MYTHACRI.ResourcePopulatorActive": "Active",
-  "MYTHACRI.ResourcePopulatorSave": "Save",
-  "MYTHACRI.ResourcePopulatorTitle": "Populate Loot List: {name}",
-  "MYTHACRI.ResourcePopulatorNoActors": "You must provide at least one valid actor.",
   "TYPES.Item.mythacri-scripts.recipe": "Recipe"
 }

--- a/module.json
+++ b/module.json
@@ -22,6 +22,13 @@
         "id": "concentrationnotifier",
         "type": "module",
         "compatibility": {}
+      },
+      {
+        "id": "simple-loot-list",
+        "type": "module",
+        "compatibility": {
+          "minimum": "11.0.3"
+        }
       }
     ]
   },

--- a/scripts/modules/applications/resource-populator.mjs
+++ b/scripts/modules/applications/resource-populator.mjs
@@ -120,11 +120,18 @@ export class ResourcePopulator extends FormApplication {
         }
       }
     });
-    const list = Object.entries(data).reduce((acc, [key, {formula}]) => {
+    let list = foundry.utils.deepClone(this.actor.getFlag("simple-loot-list", "loot-list") ?? []);
+    list = Object.entries(data).reduce((acc, [key, {formula}]) => {
       const item = items.find(item => item.flags[MODULE.ID].resource.subsubtype === key);
       if (!item) throw new Error(`No item with monster part type '${key}' exists!`);
-      return acc.concat([{uuid: item.uuid, quantity: formula}])
-    }, []);
+      const uuid = item.uuid;
+      const existing = acc.find(e => e.uuid === uuid);
+      if (existing) {
+        existing.quantity = dnd5e.dice.simplifyRollFormula(`${existing.quantity} + ${formula}`);
+        return acc;
+      }
+      return acc.concat([{uuid: uuid, quantity: formula}])
+    }, list);
     return this.actor.setFlag("simple-loot-list", "loot-list", list);
   }
 

--- a/scripts/modules/applications/resource-populator.mjs
+++ b/scripts/modules/applications/resource-populator.mjs
@@ -1,0 +1,177 @@
+import {MODULE} from "../constants.mjs";
+import {Crafting} from "../data/crafting.mjs";
+import {ResourcePopulatorModel} from "../data/models/resource-populator.mjs";
+
+export class ResourcePopulator extends FormApplication {
+  /** @override */
+  static get defaultOptions() {
+    const options = super.defaultOptions;
+    options.template = "modules/mythacri-scripts/templates/resource-populator.hbs";
+    options.classes.push("resource-populator", "mythacri-scripts");
+    return options;
+  }
+
+  /** @override */
+  get title() {
+    return game.i18n.format("MYTHACRI.ResourcePopulatorTitle", {name: this.actor.name});
+  }
+
+  /** @constructor */
+  constructor(actor, options = {}) {
+    if (!["character", "npc"].includes(actor.type)) throw new Error(`'${actor?.name}' is not a character or npc!`);
+    super(actor, options);
+    this.actor = actor;
+    this.types = ResourcePopulator.splitRaces(actor).filter(k => k in CONFIG.DND5E.creatureTypes);
+
+    const data = Object.entries(Crafting.subsubtypes).reduce((acc, [key, {label, uncommon}]) => {
+      const un = this.types.every(type => uncommon.includes(type));
+      return un ? foundry.utils.mergeObject(acc, {[`types.${key}.active`]: false}) : acc;
+    }, {});
+
+    this.model = new ResourcePopulatorModel(data);
+  }
+
+  /**
+   * Gather an object of uncommon options for this creature type.
+   * @returns {object}
+   */
+  get uncommonOptions() {
+    const options = {};
+    const {types, schema} = this.model;
+    for (const k in types) {
+      if (!types[k].active) options[k] = schema.getField(`types.${k}`).label;
+    }
+    return options;
+  }
+
+  /** @override */
+  getData() {
+    const options = this.uncommonOptions;
+    let focus = this._autofocus;
+    if (focus?.name) {
+      const name = focus.name;
+      const [, key] = name.split(".");
+      focus = key;
+    } else if (focus?.classList.contains("type-select")) {
+      focus = "select";
+    }
+    return {
+      types: Object.entries(this.model.toObject().types).reduce((acc, [key, data]) => {
+        if (data.active) acc.push({
+          ...data,
+          key: key,
+          label: this.model.schema.getField(`types.${key}`).label,
+          autofocus: focus === key
+        });
+        return acc;
+      }, []).sort((a, b) => a.label.localeCompare(b.label)),
+      options: options,
+      hasOptions: !!Object.keys(options).length,
+      focusOptions: focus === "select"
+    };
+  }
+
+  /** @override */
+  activateListeners(html) {
+    super.activateListeners(html);
+    html[0].querySelectorAll("INPUT, SELECT").forEach(n => {
+      n.addEventListener("focus", (event) => this._autofocus = event.currentTarget);
+    });
+    html[0].querySelector("[autofocus]")?.focus();
+  }
+
+  /** @override */
+  async _onChangeInput(event) {
+    const target = event.currentTarget;
+    let data;
+    if (target.classList.contains("type-select")) {
+      data = {
+        [`types.${target.value}.active`]: true,
+        [`types.${target.value}.formula`]: ""
+      };
+    } else data = this._getSubmitData();
+    this.model.updateSource(data);
+    this.render();
+  }
+
+  /** @override */
+  setPosition(pos = {}) {
+    pos.height = "auto";
+    return super.setPosition(pos);
+  }
+
+  /** @override */
+  async _updateObject(event, formData) {
+    this.model.updateSource(formData);
+    const data = this.model.toObject().types;
+    for (const k in data) {
+      if (!data[k].active) delete data[k];
+      else {
+        const valid = Roll.validate(data[k].formula || "1d2");
+        data[k].formula = valid ? (data[k].formula || "1d2") : "1d2";
+      }
+    }
+    const pack = game.settings.get(MODULE.ID, "identifiers").packs.craftingResources;
+    const items = await pack.getDocuments({
+      type: "loot",
+      flags: {
+        [MODULE.ID]: {
+          resource: {type: "monster", subtype: this.types[0], subsubtype__in: Object.keys(data)}
+        }
+      }
+    });
+    const list = Object.entries(data).reduce((acc, [key, {formula}]) => {
+      const item = items.find(item => item.flags[MODULE.ID].resource.subsubtype === key);
+      if (!item) throw new Error(`No item with monster part type '${key}' exists!`);
+      return acc.concat([{uuid: item.uuid, quantity: formula}])
+    }, []);
+    return this.actor.setFlag("simple-loot-list", "loot-list", list);
+  }
+
+  /**
+   * Utility function to split racial values.
+   * @param {Actor5e} actor     The actor.
+   * @returns {string[]}        The different 'races' to compare against.
+   */
+  static splitRaces(actor) {
+    let races = [];
+    const type = actor.system.details?.type;
+    if (type) {
+      races = this._split(type.subtype);
+      if (type.value === "custom") races.push(...this._split(type.custom));
+      else races.push(type.value);
+    }
+    return races;
+  }
+
+  /**
+   * Utility function to split a string by '/'.
+   * @param {string} str      The string to split.
+   * @returns {string[]}      The array of strings.
+   */
+  static _split(str) {
+    return str?.split("/").reduce((acc, e) => {
+      const trim = e.trim().toLowerCase();
+      if (trim.length) acc.push(trim);
+      return acc;
+    }, []) ?? [];
+  }
+
+  /**
+   * Factory method to create an instance of this application for several actors.
+   * @param {Actor5e|Actor5e[]} [actors]      An actor or array of actors.
+   * @returns {void}
+   */
+  static create(actors = []) {
+    if (!game.modules.get("simple-loot-list")?.active) {
+      throw new Error(`The module 'simple-loot-list' is not active!`);
+    }
+    actors = (actors instanceof Actor) ? [actors] : actors;
+    actors = actors.filter(a => ["character", "npc"].includes(a.type));
+    if (!actors.length) {
+      ui.notifications.warn("MYTHACRI.ResourcePopulatorNoActors", {localize: true});
+      return;
+    }
+    for (const actor of actors) new this(actor).render(true);
+  }
+}

--- a/scripts/modules/data/crafting.mjs
+++ b/scripts/modules/data/crafting.mjs
@@ -21,47 +21,159 @@ export class Crafting {
 
   /**
    * Monster sub-subtypes. The parts that can be harvested for physical parts.
+   * The 'uncommon' array contains a list of creature types from which this part is rarely or never found.
    * @type {object}
    */
   static get subsubtypes() {
     return {
-      acid: "MYTHACRI.ResourceMonsterAcid",
-      antenna: "MYTHACRI.ResourceMonsterAntenna",
-      antler: "MYTHACRI.ResourceMonsterAntler",
-      blood: "MYTHACRI.ResourceMonsterBlood",
-      bone: "MYTHACRI.ResourceMonsterBone",
-      brain: "MYTHACRI.ResourceMonsterBrain",
-      breathSac: "MYTHACRI.ResourceMonsterBreathSac",
-      carapace: "MYTHACRI.ResourceMonsterCarapace",
-      claws: "MYTHACRI.ResourceMonsterClaws",
-      dust: "MYTHACRI.ResourceMonsterDust",
-      egg: "MYTHACRI.ResourceMonsterEgg",
-      etherealIchor: "MYTHACRI.ResourceMonsterEtherealIchor",
-      eye: "MYTHACRI.ResourceMonsterEye",
-      fat: "MYTHACRI.ResourceMonsterFat",
-      feathers: "MYTHACRI.ResourceMonsterFeathers",
-      fin: "MYTHACRI.ResourceMonsterFin",
-      flesh: "MYTHACRI.ResourceMonsterFlesh",
-      heart: "MYTHACRI.ResourceMonsterHeart",
-      hide: "MYTHACRI.ResourceMonsterHide",
-      horn: "MYTHACRI.ResourceMonsterHorn",
-      instructions: "MYTHACRI.ResourceMonsterInstructions",
-      liver: "MYTHACRI.ResourceMonsterLiver",
-      mainEye: "MYTHACRI.ResourceMonsterMainEye",
-      mote: "MYTHACRI.ResourceMonsterMote",
-      mucus: "MYTHACRI.ResourceMonsterMucus",
-      oil: "MYTHACRI.ResourceMonsterOil",
-      pincer: "MYTHACRI.ResourceMonsterPincer",
-      plating: "MYTHACRI.ResourceMonsterPlating",
-      poisonGland: "MYTHACRI.ResourceMonsterPoisonGland",
-      sap: "MYTHACRI.ResourceMonsterSap",
-      scales: "MYTHACRI.ResourceMonsterScales",
-      skin: "MYTHACRI.ResourceMonsterSkin",
-      stinger: "MYTHACRI.ResourceMonsterStinger",
-      talon: "MYTHACRI.ResourceMonsterTalon",
-      teeth: "MYTHACRI.ResourceMonsterTeeth",
-      tentacle: "MYTHACRI.ResourceMonsterTentacle",
-      tusk: "MYTHACRI.ResourceMonsterTusk"
+      acid: {
+        label: "MYTHACRI.ResourceMonsterAcid",
+        uncommon: ["beast", "celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "plant", "undead"]
+      },
+      antenna: {
+        label: "MYTHACRI.ResourceMonsterAntenna",
+        uncommon: ["celestial", "construct", "dragon", "elemental", "fiend", "giant", "humanoid", "ooze", "plant", "undead"]
+      },
+      antler: {
+        label: "MYTHACRI.ResourceMonsterAntler",
+        uncommon: ["aberration", "celestial", "construct", "dragon", "elemental", "fiend", "giant", "humanoid", "ooze", "plant", "undead"]
+      },
+      blood: {
+        label: "MYTHACRI.ResourceMonsterBlood",
+        uncommon: ["celestial", "dragon", "elemental", "ooze", "plant"]
+      },
+      bone: {
+        label: "MYTHACRI.ResourceMonsterBone",
+        uncommon: ["humanoid", "ooze", "plant"]
+      },
+      brain: {
+        label: "MYTHACRI.ResourceMonsterBrain",
+        uncommon: ["dragon", "elemental", "fey", "humanoid", "monstrosity", "ooze", "plant"]
+      },
+      breathSac: {
+        label: "MYTHACRI.ResourceMonsterBreathSac",
+        uncommon: ["aberration", "celestial", "construct", "elemental", "fey", "fiend", "giant", "humanoid", "monstrosity", "ooze", "plant", "undead"]
+      },
+      carapace: {
+        label: "MYTHACRI.ResourceMonsterCarapace",
+        uncommon: ["celestial", "construct", "dragon", "fey", "fiend", "giant", "humanoid", "ooze", "plant", "undead"]
+      },
+      claws: {
+        label: "MYTHACRI.ResourceMonsterClaws",
+        uncommon: ["construct", "elemental", "giant", "humanoid", "ooze", "plant", "undead"]
+      },
+      dust: {
+        label: "MYTHACRI.ResourceMonsterDust",
+        uncommon: ["beast", "construct", "dragon", "fey", "giant", "humanoid", "monstrosity", "ooze", "plant", "undead"]
+      },
+      egg: {
+        label: "MYTHACRI.ResourceMonsterEgg",
+        uncommon: ["celestial", "construct", "elemental", "fey", "fiend", "giant", "humanoid", "ooze", "plant", "undead"]
+      },
+      etherealIchor: {
+        label: "MYTHACRI.ResourceMonsterEtherealIchor",
+        uncommon: ["aberration", "beast", "celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "monstrosity", "ooze", "plant"]
+      },
+      eye: {
+        label: "MYTHACRI.ResourceMonsterEye",
+        uncommon: ["construct", "humanoid", "ooze", "plant"]
+      },
+      fat: {
+        label: "MYTHACRI.ResourceMonsterFat",
+        uncommon: ["construct", "elemental", "humanoid", "ooze", "plant", "undead"]
+      },
+      feathers: {
+        label: "MYTHACRI.ResourceMonsterFeathers",
+        uncommon: ["aberration", "construct", "elemental", "giant", "humanoid", "ooze", "plant", "undead"]
+      },
+      fin: {
+        label: "MYTHACRI.ResourceMonsterFin",
+        uncommon: ["construct", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "ooze", "plant", "undead"]
+      },
+      flesh: {
+        label: "MYTHACRI.ResourceMonsterFlesh",
+        uncommon: ["elemental", "humanoid", "ooze", "plant"]
+      },
+      heart: {
+        label: "MYTHACRI.ResourceMonsterHeart",
+        uncommon: ["construct", "elemental", "humanoid", "ooze", "plant", "undead"]
+      },
+      hide: {
+        label: "MYTHACRI.ResourceMonsterHide",
+        uncommon: ["celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "ooze", "plant", "undead"]
+      },
+      horn: {
+        label: "MYTHACRI.ResourceMonsterHorn",
+        uncommon: ["construct", "giant", "humanoid", "ooze", "plant", "undead"]
+      },
+      instructions: {
+        label: "MYTHACRI.ResourceMonsterInstructions",
+        uncommon: ["aberration", "beast", "celestial", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "monstrosity", "ooze", "plant", "undead"]
+      },
+      liver: {
+        label: "MYTHACRI.ResourceMonsterLiver",
+        uncommon: ["construct", "elemental", "humanoid", "ooze", "plant", "undead"]
+      },
+      mainEye: {
+        label: "MYTHACRI.ResourceMonsterMainEye",
+        uncommon: ["beast", "celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "monstrosity", "ooze", "plant", "undead"]
+      },
+      mote: {
+        label: "MYTHACRI.ResourceMonsterMote",
+        uncommon: ["aberration", "beast", "celestial", "construct", "dragon", "fey", "fiend", "giant", "humanoid", "monstrosity", "ooze", "plant", "undead"]
+      },
+      mucus: {
+        label: "MYTHACRI.ResourceMonsterMucus",
+        uncommon: ["beast", "celestial", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "monstrosity", "plant", "undead"]
+      },
+      oil: {
+        label: "MYTHACRI.ResourceMonsterOil",
+        uncommon: ["beast", "celestial", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "monstrosity", "ooze", "plant", "undead"]
+      },
+      pincer: {
+        label: "MYTHACRI.ResourceMonsterPincer",
+        uncommon: ["celestial", "construct", "dragon", "elemental", "fey", "giant", "humanoid", "ooze", "plant", "undead"]
+      },
+      plating: {
+        label: "MYTHACRI.ResourceMonsterPlating",
+        uncommon: ["beast", "celestial", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "monstrosity", "ooze", "plant", "undead"]
+      },
+      poisonGland: {
+        label: "MYTHACRI.ResourceMonsterPoisonGland",
+        uncommon: ["celestial", "construct", "dragon", "elemental", "fey", "giant", "humanoid", "ooze", "plant", "undead"]
+      },
+      sap: {
+        label: "MYTHACRI.ResourceMonsterSap",
+        uncommon: ["aberration", "celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "monstrosity", "ooze", "undead"]
+      },
+      scales: {
+        label: "MYTHACRI.ResourceMonsterScales",
+        uncommon: ["beast", "construct", "elemental", "fey", "giant", "humanoid", "ooze", "plant", "undead"]
+      },
+      skin: {
+        label: "MYTHACRI.ResourceMonsterSkin",
+        uncommon: ["beast", "construct", "dragon", "elemental", "humanoid", "ooze", "undead"]
+      },
+      stinger: {
+        label: "MYTHACRI.ResourceMonsterStinger",
+        uncommon: ["beast", "celestial", "construct", "dragon", "elemental", "fey", "giant", "humanoid", "ooze", "undead"]
+      },
+      talon: {
+        label: "MYTHACRI.ResourceMonsterTalon",
+        uncommon: ["aberration", "beast", "celestial", "construct", "dragon", "elemental", "fey", "giant", "humanoid", "ooze", "plant", "undead"]
+      },
+      teeth: {
+        label: "MYTHACRI.ResourceMonsterTeeth",
+        uncommon: ["beast", "construct", "elemental", "humanoid", "ooze", "plant"]
+      },
+      tentacle: {
+        label: "MYTHACRI.ResourceMonsterTentacle",
+        uncommon: ["beast", "celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "ooze", "plant", "undead"]
+      },
+      tusk: {
+        label: "MYTHACRI.ResourceMonsterTusk",
+        uncommon: ["aberration", "beast", "celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "ooze", "plant", "undead"]
+      }
     };
   }
 
@@ -390,7 +502,7 @@ export class Crafting {
 
     if (subtype === "*") {
       return game.i18n.format("MYTHACRI.ResourceTypeLabelMonsterWildcardSubtype", {
-        subsubtype: game.i18n.localize(Crafting.subsubtypes[subsubtype])
+        subsubtype: game.i18n.localize(Crafting.subsubtypes[subsubtype].label)
       });
     }
 
@@ -403,7 +515,7 @@ export class Crafting {
     const data = {
       type: game.i18n.localize("MYTHACRI.ResourceTypeMonster"),
       subtype: game.i18n.localize(CONFIG.DND5E.creatureTypes[subtype]),
-      subsubtype: game.i18n.localize(Crafting.subsubtypes[subsubtype])
+      subsubtype: game.i18n.localize(Crafting.subsubtypes[subsubtype].label)
     };
     return game.i18n.format("MYTHACRI.ResourceTypeLabelMonster", data);
   }

--- a/scripts/modules/data/crafting.mjs
+++ b/scripts/modules/data/crafting.mjs
@@ -28,15 +28,22 @@ export class Crafting {
     return {
       acid: {
         label: "MYTHACRI.ResourceMonsterAcid",
-        uncommon: ["beast", "celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "plant", "undead"]
+        uncommon: [
+          "beast", "celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "plant", "undead"
+        ]
       },
       antenna: {
         label: "MYTHACRI.ResourceMonsterAntenna",
-        uncommon: ["celestial", "construct", "dragon", "elemental", "fiend", "giant", "humanoid", "ooze", "plant", "undead"]
+        uncommon: [
+          "celestial", "construct", "dragon", "elemental", "fiend", "giant", "humanoid", "ooze", "plant", "undead"
+        ]
       },
       antler: {
         label: "MYTHACRI.ResourceMonsterAntler",
-        uncommon: ["aberration", "celestial", "construct", "dragon", "elemental", "fiend", "giant", "humanoid", "ooze", "plant", "undead"]
+        uncommon: [
+          "aberration", "celestial", "construct", "dragon", "elemental", "fiend", "giant",
+          "humanoid", "ooze", "plant", "undead"
+        ]
       },
       blood: {
         label: "MYTHACRI.ResourceMonsterBlood",
@@ -52,11 +59,16 @@ export class Crafting {
       },
       breathSac: {
         label: "MYTHACRI.ResourceMonsterBreathSac",
-        uncommon: ["aberration", "celestial", "construct", "elemental", "fey", "fiend", "giant", "humanoid", "monstrosity", "ooze", "plant", "undead"]
+        uncommon: [
+          "aberration", "celestial", "construct", "elemental", "fey", "fiend", "giant", "humanoid",
+          "monstrosity", "ooze", "plant", "undead"
+        ]
       },
       carapace: {
         label: "MYTHACRI.ResourceMonsterCarapace",
-        uncommon: ["celestial", "construct", "dragon", "fey", "fiend", "giant", "humanoid", "ooze", "plant", "undead"]
+        uncommon: [
+          "celestial", "construct", "dragon", "fey", "fiend", "giant", "humanoid", "ooze", "plant", "undead"
+        ]
       },
       claws: {
         label: "MYTHACRI.ResourceMonsterClaws",
@@ -64,15 +76,22 @@ export class Crafting {
       },
       dust: {
         label: "MYTHACRI.ResourceMonsterDust",
-        uncommon: ["beast", "construct", "dragon", "fey", "giant", "humanoid", "monstrosity", "ooze", "plant", "undead"]
+        uncommon: [
+          "beast", "construct", "dragon", "fey", "giant", "humanoid", "monstrosity", "ooze", "plant", "undead"
+        ]
       },
       egg: {
         label: "MYTHACRI.ResourceMonsterEgg",
-        uncommon: ["celestial", "construct", "elemental", "fey", "fiend", "giant", "humanoid", "ooze", "plant", "undead"]
+        uncommon: [
+          "celestial", "construct", "elemental", "fey", "fiend", "giant", "humanoid", "ooze", "plant", "undead"
+        ]
       },
       etherealIchor: {
         label: "MYTHACRI.ResourceMonsterEtherealIchor",
-        uncommon: ["aberration", "beast", "celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "monstrosity", "ooze", "plant"]
+        uncommon: [
+          "aberration", "beast", "celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant",
+          "humanoid", "monstrosity", "ooze", "plant"
+        ]
       },
       eye: {
         label: "MYTHACRI.ResourceMonsterEye",
@@ -100,7 +119,10 @@ export class Crafting {
       },
       hide: {
         label: "MYTHACRI.ResourceMonsterHide",
-        uncommon: ["celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "ooze", "plant", "undead"]
+        uncommon: [
+          "celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant", "humanoid",
+          "ooze", "plant", "undead"
+        ]
       },
       horn: {
         label: "MYTHACRI.ResourceMonsterHorn",
@@ -108,7 +130,10 @@ export class Crafting {
       },
       instructions: {
         label: "MYTHACRI.ResourceMonsterInstructions",
-        uncommon: ["aberration", "beast", "celestial", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "monstrosity", "ooze", "plant", "undead"]
+        uncommon: [
+          "aberration", "beast", "celestial", "dragon", "elemental", "fey", "fiend", "giant", "humanoid",
+          "monstrosity", "ooze", "plant", "undead"
+        ]
       },
       liver: {
         label: "MYTHACRI.ResourceMonsterLiver",
@@ -116,35 +141,58 @@ export class Crafting {
       },
       mainEye: {
         label: "MYTHACRI.ResourceMonsterMainEye",
-        uncommon: ["beast", "celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "monstrosity", "ooze", "plant", "undead"]
+        uncommon: [
+          "beast", "celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant",
+          "humanoid", "monstrosity", "ooze", "plant", "undead"
+        ]
       },
       mote: {
         label: "MYTHACRI.ResourceMonsterMote",
-        uncommon: ["aberration", "beast", "celestial", "construct", "dragon", "fey", "fiend", "giant", "humanoid", "monstrosity", "ooze", "plant", "undead"]
+        uncommon: [
+          "aberration", "beast", "celestial", "construct", "dragon", "fey", "fiend", "giant",
+          "humanoid", "monstrosity", "ooze", "plant", "undead"
+        ]
       },
       mucus: {
         label: "MYTHACRI.ResourceMonsterMucus",
-        uncommon: ["beast", "celestial", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "monstrosity", "plant", "undead"]
+        uncommon: [
+          "beast", "celestial", "dragon", "elemental", "fey", "fiend", "giant", "humanoid",
+          "monstrosity", "plant", "undead"
+        ]
       },
       oil: {
         label: "MYTHACRI.ResourceMonsterOil",
-        uncommon: ["beast", "celestial", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "monstrosity", "ooze", "plant", "undead"]
+        uncommon: [
+          "beast", "celestial", "dragon", "elemental", "fey", "fiend", "giant", "humanoid",
+          "monstrosity", "ooze", "plant", "undead"
+        ]
       },
       pincer: {
         label: "MYTHACRI.ResourceMonsterPincer",
-        uncommon: ["celestial", "construct", "dragon", "elemental", "fey", "giant", "humanoid", "ooze", "plant", "undead"]
+        uncommon: [
+          "celestial", "construct", "dragon", "elemental", "fey", "giant", "humanoid", "ooze", "plant", "undead"
+        ]
       },
       plating: {
         label: "MYTHACRI.ResourceMonsterPlating",
-        uncommon: ["beast", "celestial", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "monstrosity", "ooze", "plant", "undead"]
+        uncommon: [
+          "beast", "celestial", "dragon", "elemental", "fey", "fiend", "giant", "humanoid",
+          "monstrosity", "ooze", "plant", "undead"
+        ]
       },
       poisonGland: {
         label: "MYTHACRI.ResourceMonsterPoisonGland",
-        uncommon: ["celestial", "construct", "dragon", "elemental", "fey", "giant", "humanoid", "ooze", "plant", "undead"]
+        uncommon: [
+          "celestial", "construct", "dragon", "elemental", "fey", "giant", "humanoid",
+          "ooze", "plant", "undead"
+        ]
       },
       sap: {
         label: "MYTHACRI.ResourceMonsterSap",
-        uncommon: ["aberration", "celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "monstrosity", "ooze", "undead"]
+        uncommon: [
+          "aberration", "celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant",
+          "humanoid", "monstrosity", "ooze", "undead"
+        ]
       },
       scales: {
         label: "MYTHACRI.ResourceMonsterScales",
@@ -156,11 +204,16 @@ export class Crafting {
       },
       stinger: {
         label: "MYTHACRI.ResourceMonsterStinger",
-        uncommon: ["beast", "celestial", "construct", "dragon", "elemental", "fey", "giant", "humanoid", "ooze", "undead"]
+        uncommon: [
+          "beast", "celestial", "construct", "dragon", "elemental", "fey", "giant", "humanoid", "ooze", "undead"
+        ]
       },
       talon: {
         label: "MYTHACRI.ResourceMonsterTalon",
-        uncommon: ["aberration", "beast", "celestial", "construct", "dragon", "elemental", "fey", "giant", "humanoid", "ooze", "plant", "undead"]
+        uncommon: [
+          "aberration", "beast", "celestial", "construct", "dragon", "elemental", "fey", "giant",
+          "humanoid", "ooze", "plant", "undead"
+        ]
       },
       teeth: {
         label: "MYTHACRI.ResourceMonsterTeeth",
@@ -168,11 +221,17 @@ export class Crafting {
       },
       tentacle: {
         label: "MYTHACRI.ResourceMonsterTentacle",
-        uncommon: ["beast", "celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "ooze", "plant", "undead"]
+        uncommon: [
+          "beast", "celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant",
+          "humanoid", "ooze", "plant", "undead"
+        ]
       },
       tusk: {
         label: "MYTHACRI.ResourceMonsterTusk",
-        uncommon: ["aberration", "beast", "celestial", "construct", "dragon", "elemental", "fey", "fiend", "giant", "humanoid", "ooze", "plant", "undead"]
+        uncommon: [
+          "aberration", "beast", "celestial", "construct", "dragon", "elemental", "fey", "fiend",
+          "giant", "humanoid", "ooze", "plant", "undead"
+        ]
       }
     };
   }

--- a/scripts/modules/data/models/resource-populator.mjs
+++ b/scripts/modules/data/models/resource-populator.mjs
@@ -1,0 +1,18 @@
+import {Crafting} from "../crafting.mjs";
+
+/** Utility model for holding and refreshing data when creating loot on an actor. */
+export class ResourcePopulatorModel extends foundry.abstract.DataModel {
+  /** @override */
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    return {
+      types: new fields.SchemaField(Object.entries(Crafting.subsubtypes).reduce((acc, [key, {label}]) => {
+        acc[key] = new fields.SchemaField({
+          active: new fields.BooleanField({initial: true}),
+          formula: new fields.StringField({initial: "1d2", required: true}),
+        }, {label: label});
+        return acc;
+      }, {}))
+    };
+  }
+}

--- a/scripts/modules/interface.mjs
+++ b/scripts/modules/interface.mjs
@@ -1,3 +1,4 @@
+import {ResourcePopulator} from "./applications/resource-populator.mjs";
 import {Crafting} from "./data/crafting.mjs";
 import {Encounter} from "./data/encounter.mjs";
 import {Mayhem} from "./data/mayhem.mjs";
@@ -13,7 +14,8 @@ export class PublicInterface {
       mayhem: Mayhem,
       crafting: Crafting,
       encounter: Encounter,
-      experience: ExperiencePips
+      experience: ExperiencePips,
+      resource: ResourcePopulator
     };
   }
 }

--- a/templates/parts/resource-types.hbs
+++ b/templates/parts/resource-types.hbs
@@ -22,7 +22,7 @@
 <div class="form-group resource">
   <label>{{localize subsubtypeLabel}}</label>
   <select name="flags.mythacri-scripts.resource.subsubtype" {{disabled disable}}>
-    {{selectOptions monsterPartOptions selected=subsubtype localize=true sort=true blank="-"}}
+    {{selectOptions monsterPartOptions selected=subsubtype localize=true labelAttr="label" sort=true blank="-"}}
   </select>
 </div>
 {{/if}}

--- a/templates/resource-populator.hbs
+++ b/templates/resource-populator.hbs
@@ -1,0 +1,28 @@
+<form class="dnd5e">
+  {{#each types as |type|}}
+  <div class="form-group">
+    <label>{{localize type.label}}</label>
+    <div class="form-fields">
+      <input type="text" name="types.{{type.key}}.formula" value="{{type.formula}}" placeholder="1d2" {{#if autofocus}}autofocus{{/if}}>
+      <label class="checkbox">
+        <input type="checkbox" name="types.{{type.key}}.active" {{checked type.active}}>
+        {{localize "MYTHACRI.ResourcePopulatorActive"}}
+      </label>
+    </div>
+  </div>
+  {{/each}}
+  {{#if hasOptions}}
+  <div class="form-group">
+    <div class="form-fields">
+      <select class="type-select" {{#if focusOptions}}autofocus{{/if}}>
+        {{selectOptions options localize=true blank="-"}}
+      </select>
+    </div>
+  </div>
+  {{/if}}
+  <footer>
+    <button type="submit">
+      <i class="fa-solid fa-coins"></i> {{localize "MYTHACRI.ResourcePopulatorSave"}}
+    </button>
+  </footer>
+</form>


### PR DESCRIPTION
Closes #123.

Introducing the 'resource populator', allowing the GM to populate actors with monster part resources as loot using the `Simple Loot List` module.

This method can be accessed with `mythacri.resource.create`, which takes an actor or an array of actors.

Examples for all selected tokens, or one selected token.
```js
const actors = canvas.tokens.controlled.map(token => token.actor);
mythacri.resource.create(actors);
```
```js
mythacri.resource.create(token.actor);
```
