### PR TITLE
Remove children Object from Primordial language

### DIFF
--- a/scripts/modules/system-config.mjs
+++ b/scripts/modules/system-config.mjs
@@ -53,10 +53,7 @@ export class SystemConfig {
       "-=druidic": null, // delete 'druidic'
       "exotic.children.-=gith": null, // delete 'gith'
       "exotic.children.-=gnoll": null, // delete 'gnoll'
-      "exotic.children.primordial.children.-=ignan": null, // delete 'ignan, terran, auran, aquan'
-      "exotic.children.primordial.children.-=terran": null, // delete 'ignan, terran, auran, aquan'
-      "exotic.children.primordial.children.-=auran": null, // delete 'ignan, terran, auran, aquan'
-      "exotic.children.primordial.children.-=aquan": null, // delete 'ignan, terran, auran, aquan'
+      "exotic.children.primordial.-=children": null, // delete 'ignan, terran, auran, aquan'
       "standard.children.-=gnomish": null, // delete 'gnomish'
       "standard.children.-=orc": null // delete 'orc'
     }, {performDeletions: true});


### PR DESCRIPTION
This doesn't change any functionality, but prevents Primordial from showing up as a category (bolded), by removing the entire `children` object, rather than each child individually. We can do this now without issue due to v2.4.1 of the system.