### PR TITLE
[#128, #129] Fix overflow, create button

### DIFF
--- a/scripts/modules/applications/crafting-application.mjs
+++ b/scripts/modules/applications/crafting-application.mjs
@@ -50,7 +50,7 @@ export class CraftingApplication extends Application {
     const context = await Promise.all(recipes.map(async (item) => {
       const components = item.system.getComponents();
       const labels = Object.entries(components).map(([id, qty]) => {
-        const items = this.getPossibleResources(id, qty);
+        const items = this.getPossibleResources(id);
         const max = items.length ? Math.max(...items.map(item => item.system.quantity)) : 0;
         return {
           cssClass: (max < qty) ? "missing" : "",

--- a/scripts/modules/applications/crafting-application.mjs
+++ b/scripts/modules/applications/crafting-application.mjs
@@ -113,7 +113,7 @@ export class CraftingApplication extends Application {
         return false;
       }
       return RecipeData.knowsRecipe(this.actor, idx._id, idx.system.type.value, idx.system.crafting.basic);
-    });
+    }).sort((a, b) => a.name.localeCompare(b.name));
   }
 
   /**
@@ -174,7 +174,12 @@ export class CraftingApplication extends Application {
   /** @override */
   activateListeners(html) {
     super.activateListeners(html);
-    html[0].querySelectorAll(".create").forEach(n => n.addEventListener("click", this._onCreate.bind(this)));
+    html[0].querySelectorAll(".create").forEach(n => {
+      n.addEventListener("click", this._onCreate.bind(this));
+    });
+    html[0].querySelectorAll(".header .name .label").forEach(n => {
+      n.addEventListener("click", this._toggleDescription.bind(this));
+    });
   }
 
   /* ------------------------------------ */
@@ -191,6 +196,14 @@ export class CraftingApplication extends Application {
     const recipe = await fromUuid(event.currentTarget.dataset.uuid);
     const canCreate = this.canCreateRecipe(recipe);
     return !canCreate ? this.render() : new CraftingHandler(this.actor, this.type, recipe).render(true);
+  }
+
+  /**
+   * Slide a description up or down.
+   * @param {PointerEvent} event
+   */
+  _toggleDescription(event) {
+    event.currentTarget.closest(".recipe").classList.toggle("expanded");
   }
 }
 

--- a/scripts/modules/applications/crafting-application.mjs
+++ b/scripts/modules/applications/crafting-application.mjs
@@ -96,7 +96,8 @@ export class CraftingApplication extends Application {
         "system.type.value",
         "system.crafting.basic",
         "system.crafting.target",
-        "system.crafting.components"
+        "system.crafting.components",
+        "system.description.value"
       ]
     })).filter(idx => {
       const isType = (idx.type === "mythacri-scripts.recipe") && (idx.system.type.value === this.type);

--- a/scripts/modules/applications/crafting-application.mjs
+++ b/scripts/modules/applications/crafting-application.mjs
@@ -1,5 +1,6 @@
 import {MODULE} from "../constants.mjs";
 import {Crafting} from "../data/crafting.mjs";
+import {RecipeData} from "../data/models/recipe-item.mjs";
 
 /**
  * Main crafting application class to handle all types of crafting.
@@ -47,8 +48,8 @@ export class CraftingApplication extends Application {
       spirit: "fire-flame-simple"
     }[this.type];
     const recipes = await this.getAvailableRecipes();
-    const context = await Promise.all(recipes.map(async (item) => {
-      const components = item.system.getComponents();
+    const context = recipes.map(idx => {
+      const components = RecipeData.getComponents(idx.system.crafting.components);
       const labels = Object.entries(components).map(([id, qty]) => {
         const items = this.getPossibleResources(id);
         const max = items.length ? Math.max(...items.map(item => item.system.quantity)) : 0;
@@ -58,22 +59,19 @@ export class CraftingApplication extends Application {
         };
       });
 
-      const qty = item.system.crafting.target.quantity || 1;
-      const target = await item.system.getTarget();
-      const targetLink = await TextEditor.enrichHTML(target.link, {async: true});
+      const qty = idx.system.crafting.target.quantity || 1;
 
       return {
-        recipe: item,
-        canCreate: this.canCreateRecipe(item),
-        target: targetLink,
+        recipe: idx,
+        canCreate: this.canCreateRecipe(idx),
         isStack: qty > 1,
         stack: qty,
-        isBasic: item.system.crafting.basic,
+        isBasic: idx.system.crafting.basic,
         labels: labels,
         components: components,
         icon: icon
       };
-    }));
+    });
 
     const [unavailable, available] = context.partition(c => c.canCreate);
     return {unavailable, available};
@@ -87,35 +85,43 @@ export class CraftingApplication extends Application {
 
   /**
    * Retrieve all recipes that are of this type and that this actor has learned (or are basic).
-   * @returns {Promise<Item5e[]>}
+   * @returns {Promise<object[]>}     Compendium index entries.
    */
   async getAvailableRecipes() {
     const pack = game.settings.get(MODULE.ID, "identifiers").packs.craftingRecipes;
     if (!pack) throw new Error("There is no valid crafting recipes compendium in the settings.");
 
-    const documents = await pack.getDocuments({type: "mythacri-scripts.recipe", system: {type: {value: this.type}}});
-    return documents.filter(item => {
-      const hasT = item.system.hasTarget;
+    return (await pack.getIndex({
+      fields: [
+        "system.type.value",
+        "system.crafting.basic",
+        "system.crafting.target",
+        "system.crafting.components"
+      ]
+    })).filter(idx => {
+      const isType = (idx.type === "mythacri-scripts.recipe") && (idx.system.type.value === this.type);
+      if (!isType) return false;
+      const hasT = RecipeData.hasTarget(idx.system.crafting.target.uuid);
       if (!hasT) {
-        console.warn(`Recipe item '${item.name}' has no valid target.`);
+        console.warn(`Recipe item '${idx.name}' has no valid target.`);
         return false;
       }
-      const hasC = item.system.hasComponents;
+      const hasC = RecipeData.hasComponents(idx.system.crafting.components);
       if (!hasC) {
-        console.warn(`Recipe item '${item.name}' has no valid components.`);
+        console.warn(`Recipe item '${idx.name}' has no valid components.`);
         return false;
       }
-      return item.system.knowsRecipe(this.actor);
+      return RecipeData.knowsRecipe(this.actor, idx._id, idx.system.type.value, idx.system.crafting.basic);
     });
   }
 
   /**
    * Does the actor have the needed components for this recipe?
-   * @param {Item5e} item     The recipe.
+   * @param {object} idx     The recipe retrieved from compendium index.
    * @returns {boolean}
    */
-  canCreateRecipe(item) {
-    const components = item.system.getComponents();
+  canCreateRecipe(idx) {
+    const components = RecipeData.getComponents(idx.system.crafting.components);
     const resources = this.actor.items.reduce((acc, item) => {
       const validFor = Object.keys(components).find(id => Crafting.validResourceForComponent(item, id));
       if (validFor) acc[validFor] = Math.max(acc[validFor] ?? 0, item.system.quantity);
@@ -153,13 +159,13 @@ export class CraftingApplication extends Application {
   }
 
   /** @override */
-  async render(...args) {
+  render(...args) {
     this.actor.apps[`crafting-${this.type}`] = this;
     return super.render(...args);
   }
 
   /** @override */
-  async close(...args) {
+  close(...args) {
     delete this.actor.apps[`crafting-${this.type}`];
     return super.close(...args);
   }

--- a/styles/mythacri.css
+++ b/styles/mythacri.css
@@ -278,15 +278,17 @@
   color: gray;
 }
 .mythacri-scripts.crafting .recipe .details {
-  display: flex;
+  display: none;
   gap: 1em;
+}
+.mythacri-scripts.crafting .recipe.expanded .details {
+  display: flex;
 }
 .mythacri-scripts.crafting .recipe .details .description {
   flex: 3;
   font-style: italic;
   max-width: 60%;
-  overflow: hidden auto;
-  max-height: 250px;
+  overflow: hidden;
 }
 .mythacri-scripts.crafting .recipe .details .components {
   padding-top: 5px;

--- a/styles/mythacri.css
+++ b/styles/mythacri.css
@@ -277,12 +277,6 @@
   font-style: italic;
   color: gray;
 }
-.mythacri-scripts.crafting .recipe .target {
-  border-top: 2px groove;
-  border-bottom: 2px groove;
-  padding: 0.5em 0;
-  margin-top: 0.5em;
-}
 .mythacri-scripts.crafting .recipe .details {
   display: flex;
   gap: 1em;
@@ -385,6 +379,9 @@
 }
 .mythacri-scripts.crafting-handler .components .component-header .counter {
   color: gray;
+}
+.mythacri-scripts.crafting-handler .components .component-header img {
+  border-radius: 50%;
 }
 .mythacri-scripts.crafting-handler .components .component-header .label {
   font-weight: bold;

--- a/styles/mythacri.css
+++ b/styles/mythacri.css
@@ -355,6 +355,9 @@
 .mythacri-scripts.crafting-handler .column:not(:last-child) {
   border-right: 2px groove;
 }
+.mythacri-scripts.crafting-handler .column .resources {
+  flex: 1;
+}
 .mythacri-scripts.crafting-handler .components .component-header,
 .mythacri-scripts.crafting-handler .components .component {
   display: flex;

--- a/styles/mythacri.css
+++ b/styles/mythacri.css
@@ -264,6 +264,7 @@
   font-family: "Modesto Condensed";
   display: flex;
   justify-content: space-between;
+  align-items: center;
 }
 .mythacri-scripts.crafting .recipe .header .name .create {
   white-space: nowrap;
@@ -290,7 +291,8 @@
   flex: 3;
   font-style: italic;
   max-width: 60%;
-  overflow: hidden;
+  overflow: hidden auto;
+  max-height: 250px;
 }
 .mythacri-scripts.crafting .recipe .details .components {
   padding-top: 5px;

--- a/styles/mythacri.css
+++ b/styles/mythacri.css
@@ -265,6 +265,13 @@
   display: flex;
   justify-content: space-between;
 }
+.mythacri-scripts.crafting .recipe .header .name .create {
+  white-space: nowrap;
+  max-width: 30%;
+  font-size: 20px;
+  font-family: 'Modesto Condensed';
+  padding: 4px;
+}
 .mythacri-scripts.crafting .recipe .header .basic {
   font-style: italic;
   color: gray;
@@ -282,6 +289,8 @@
 .mythacri-scripts.crafting .recipe .details .description {
   flex: 3;
   font-style: italic;
+  max-width: 60%;
+  overflow: hidden;
 }
 .mythacri-scripts.crafting .recipe .details .components {
   padding-top: 5px;
@@ -331,6 +340,7 @@
 }
 .mythacri-scripts.crafting-handler .header img {
   height: 50px;
+  width: 50px;
   border: none;
 }
 .mythacri-scripts.crafting-handler .components {

--- a/templates/crafting-handler.hbs
+++ b/templates/crafting-handler.hbs
@@ -14,11 +14,16 @@
         <span class="label">{{label}}</span>
         <span class="counter">({{ifThen assigned assigned.system.quantity 0}}/{{quantity}})</span>
       </div>
-      {{#each resources}}
-      <a class="component" data-identifier="{{../identifier}}" data-item-id="{{resource.id}}">
-        <img src="{{resource.img}}" {{#if active}} class="active" {{/if}} data-tooltip="{{resource.name}}">
-      </a>
-      {{/each}}
+      <div class="resources">
+        {{#each resources}}
+        <div class="component">
+          <a data-identifier="{{../identifier}}" data-item-id="{{resource.id}}">
+            <img src="{{resource.img}}" {{#if active}} class="active" {{/if}} data-tooltip="{{resource.name}}">
+          </a>
+          <span class="quantity">{{localize "DND5E.Quantity"}}: {{resource.system.quantity}}</span>
+        </div>
+        {{/each}}
+      </div>
     </div>
     {{/each}}
   </div>

--- a/templates/parts/crafting-recipe.hbs
+++ b/templates/parts/crafting-recipe.hbs
@@ -3,10 +3,10 @@
     <div class="name">
       {{recipe.name}}
       {{#if canCreate}}
-      <a class="create" data-uuid="{{recipe.uuid}}">
+      <button type="button" class="create" data-uuid="{{recipe.uuid}}">
         {{localize "MYTHACRI.CraftingCreate"}}
         <i class="fa-solid fa-{{icon}}"></i>
-      </a>
+      </button>
       {{/if}}
     </div>
     <div class="basic">{{#if isBasic}}{{localize "MYTHACRI.ItemRecipeBasic"}}{{/if}}</div>

--- a/templates/parts/crafting-recipe.hbs
+++ b/templates/parts/crafting-recipe.hbs
@@ -1,7 +1,7 @@
 <div class="recipe">
   <div class="header">
     <div class="name">
-      {{recipe.name}}
+      <a class="label">{{recipe.name}}</a>
       {{#if canCreate}}
       <button type="button" class="create" data-uuid="{{recipe.uuid}}">
         <i class="fa-solid fa-{{icon}}"></i>

--- a/templates/parts/crafting-recipe.hbs
+++ b/templates/parts/crafting-recipe.hbs
@@ -4,16 +4,12 @@
       {{recipe.name}}
       {{#if canCreate}}
       <button type="button" class="create" data-uuid="{{recipe.uuid}}">
-        {{localize "MYTHACRI.CraftingCreate"}}
         <i class="fa-solid fa-{{icon}}"></i>
+        {{localize "MYTHACRI.CraftingCreate"}}
       </button>
       {{/if}}
     </div>
     <div class="basic">{{#if isBasic}}{{localize "MYTHACRI.ItemRecipeBasic"}}{{/if}}</div>
-  </div>
-  <div class="target">
-    {{{target}}}
-    {{#if isStack}}({{stack}}){{/if}}
   </div>
   <div class="details">
     <div class="description">{{{recipe.system.description.value}}}</div>


### PR DESCRIPTION
Closes #128.
Closes #129.
Closes #131.

- Wide descriptions no longer overflow the crafting UI.
- Long names no longer cause the 'Create' button to break its line (it has been replaced with a button as well to be more visible).
- Fix inadequate quantity resources being filtered out (for the purpose of rendering, only).
- Moved over to using `getIndex` rather than `getDocuments`, reducing the amount of async calls to 1. Rendering can still be slow, but now it *should* be only due to the sheer size of the UI with 100+ recipes, not due to any async calls.

![image](https://github.com/Mythacri/Mythacri-Foundry-Scripts/assets/50169243/fb8ae6fa-b977-46ca-8253-136c9a3e3324)
