### PR TITLE
Storage sheet

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -218,5 +218,8 @@
   "MYTHACRI.WeaponPropertySuperheavy": "Superheavy",
   "MYTHACRI.WeaponPropertyTension": "Tension",
   "MYTHACRI.WeaponPropertyTwinshot": "Twinshot",
+  "MYTHACRI.SheetStorage": "Mythacri Storage Sheet",
+  "MYTHACRI.SheetRecipe": "Mythacri Recipe Sheet",
+  "TYPES.Actor.mythacri-scripts.storage": "Storage",
   "TYPES.Item.mythacri-scripts.recipe": "Recipe"
 }

--- a/languages/en.json
+++ b/languages/en.json
@@ -220,6 +220,16 @@
   "MYTHACRI.WeaponPropertyTwinshot": "Twinshot",
   "MYTHACRI.SheetStorage": "Mythacri Storage Sheet",
   "MYTHACRI.SheetRecipe": "Mythacri Recipe Sheet",
+  "MYTHACRI.StorageTabGear": "Gear",
+  "MYTHACRI.StorageTabConsumables": "Consumables",
+  "MYTHACRI.StorageTabLoot": "Loot",
+  "MYTHACRI.StorageTabResources": "Resources",
+  "MYTHACRI.ConsumableTypeOther": "Other Consumables",
+  "MYTHACRI.LootTypeOther": "Other Loot",
+  "MYTHACRI.Capacity": "Capacity",
+  "MYTHACRI.CapacityMax": "Max Capacity",
+  "MYTHACRI.CapacityType": "Capacity Type",
+  "MYTHACRI.CapacityConfig": "Modify Attributes",
   "TYPES.Actor.mythacri-scripts.storage": "Storage",
   "TYPES.Item.mythacri-scripts.recipe": "Recipe"
 }

--- a/module.json
+++ b/module.json
@@ -65,6 +65,9 @@
   "documentTypes": {
     "Item": {
       "recipe": {}
+    },
+    "Actor": {
+      "storage": {}
     }
   },
   "url": "https://github.com/Mythacri/Mythacri-Foundry-Scripts",

--- a/scripts/modules/applications/storage-sheet.mjs
+++ b/scripts/modules/applications/storage-sheet.mjs
@@ -1,7 +1,9 @@
+import {MODULE} from "../constants.mjs";
+
 /**
  * Actor sheet for storage-type actors.
  */
-export class StorageSheet extends ActorSheet {
+export class StorageSheet extends dnd5e.applications.actor.ActorSheet5e {
   /** @override */
   static get defaultOptions() {
     const options = super.defaultOptions;
@@ -17,37 +19,240 @@ export class StorageSheet extends ActorSheet {
   }
 
   /**
+   * IDs for items on the sheet that have been expanded.
+   * @type {Set<string>}
+   * @protected
+   */
+  _expanded = new Set();
+
+  /**
    * A set of item types that should be prevented from being dropped on this type of actor sheet.
    * @type {Set<string>}
    */
-  static unsupportedItemTypes = new Set(["feat", "race", "class", "subclass", "background"]);
+  unsupportedItemTypes = new Set(["feat", "race", "class", "subclass", "background", "mythacri-scripts.recipe"]);
 
   /** @override */
   async getData(options = {}) {
-    const data = await super.getData(options);
+    const data = {
+      actor: this.document,
+      system: this.document.system,
+      items: this.document.items.contents,
+      itemContext: {},
+      owner: this.document.isOwner,
+      limited: this.document.limited,
+      options: this.options,
+      editable: this.isEditable,
+      cssClass: this.document.isOwner ? "editable" : "locked",
+      config: CONFIG.DND5E,
+      rollableClass: this.isEditable ? "rollable" : "",
+      labels: {
+        currencies: Object.entries(CONFIG.DND5E.currencies).reduce((obj, [k, c]) => {
+          obj[k] = c.label;
+          return obj;
+        }, {})
+      }
+    };
+    this._prepareItems(data);
+    data.expandedData = {};
+    for (const id of this._expanded) {
+      const item = this.actor.items.get(id);
+      if (item) data.expandedData[id] = await item.getChatData({secrets: this.document.isOwner});
+    }
     return data;
   }
 
-  /** @override */
-  setPosition(pos = {}) {
-    if (!pos.height) pos.height = "auto";
-    return super.setPosition(pos);
+  /**
+   * Prepare the data structure for items which appear on the actor sheet.
+   * Each subclass overrides this method to implement type-specific logic.
+   * @protected
+   */
+  _prepareItems(context) {
+
+    // Categorize items as inventory, spellbook, features, and classes
+    const inventory = {};
+    for (const type of ["weapon", "equipment", "consumable", "tool", "backpack", "loot"]) {
+      inventory[type] = {label: `${CONFIG.Item.typeLabels[type]}Pl`, items: [], dataset: {type}};
+    }
+
+    context.itemContext = {};
+
+    // Partition items by category
+    const items = context.items.reduce((obj, item) => {
+      const quantity = item.system.quantity;
+
+      // Item details
+      const ctx = context.itemContext[item._id] ??= {};
+      ctx.isStack = Number.isNumeric(quantity) && (quantity !== 1);
+
+      // Prepare data needed to display expanded sections
+      ctx.isExpanded = this._expanded.has(item._id);
+
+      // Item usage
+      ctx.hasUses = item.hasLimitedUses;
+
+      // Classify items into types
+      let category;
+      let label;
+      if (item.type === "weapon") {
+        category = "weapons";
+        label = `${CONFIG.Item.typeLabels[item.type]}Pl`;
+      } else if (item.isArmor) {
+        category = "armors";
+        label = "DND5E.Armor";
+      } else if (item.type === "equipment") {
+        category = "equipment";
+        label = `${CONFIG.Item.typeLabels[item.type]}Pl`;
+      } else if (item.type === "backpack") {
+        category = "backpacks";
+        label = `${CONFIG.Item.typeLabels[item.type]}Pl`;
+      } else if (item.type === "tool") {
+        category = "tools";
+        label = `${CONFIG.Item.typeLabels[item.type]}Pl`;
+      } else if (item.type === "consumable") {
+        const ct = item.system.consumableType;
+        if (ct in CONFIG.DND5E.consumableTypes) {
+          category = ct;
+          label = CONFIG.DND5E.consumableTypes[ct];
+        } else {
+          category = "consumable-other";
+          label = "MYTHACRI.ConsumableTypeOther";
+        }
+      } else if (item.type === "loot") {
+        const id = mythacri.crafting.getIdentifier(item);
+        if (id && mythacri.crafting.validIdentifier(id)) {
+          category = item.flags[MODULE.ID].resource.type;
+          label = `MYTHACRI.ResourceType${category.capitalize()}`;
+        } else {
+          const lt = item.system.type.value;
+          if (lt in CONFIG.DND5E.lootTypes) {
+            category = lt;
+            label = CONFIG.DND5E.lootTypes[lt].label;
+          } else {
+            category = "loot-other";
+            label = "MYTHACRI.LootTypeOther";
+          }
+        }
+      }
+      if (!category) {
+        console.warn("No category:", category, item);
+        return obj;
+      }
+      obj[category] ??= {};
+      obj[category].label ??= label;
+      obj[category].items ??= [];
+      obj[category].items.push(item);
+      obj[category].dataset ??= {};
+      return obj;
+    }, {});
+
+    // Assign and return
+    context.gear = [items.weapons, items.armors, items.equipment, items.backpacks, items.tools];
+    context.consumables = Object.keys(CONFIG.DND5E.consumableTypes).map(k => items[k]).concat([items["consumable-other"]]);
+    context.loot = Object.keys(CONFIG.DND5E.lootTypes).map(k => items[k]).concat([items["loot-other"]]);
+    context.resources = Object.keys(mythacri.crafting.resourceTypes).map(k => items[k]);
+    ["gear", "consumables", "loot", "resources"].forEach(k => context[k] = context[k].filter(u => u));
   }
 
   /** @override */
-  async _onDrop(event) {
-    const data = TextEditor.getDragEventData(event);
-    if (data.type !== "Item") return;
-    const item = await fromUuid(data.uuid);
-    if (this.unsupportedItemTypes.has(item.type)) {
-      ui.notifications.warn("You cannot drop a", item.type, "onto the storage actor.");
-      return null;
+  async _onDropActor(event, data) {
+    return false;
+  }
+
+  /** @override */
+  async _onDropActiveEffect(event, data) {
+    return false;
+  }
+
+  /** @override */
+  async _onDropSingleItem(itemData) {
+    // Check to make sure items of this type are allowed on this actor
+    if (this.unsupportedItemTypes.has(itemData.type)) {
+      ui.notifications.warn(game.i18n.format("DND5E.ActorWarningInvalidItem", {
+        itemType: game.i18n.localize(CONFIG.Item.typeLabels[itemData.type]),
+        actorType: game.i18n.localize(CONFIG.Actor.typeLabels[this.actor.type])
+      }));
+      return false;
     }
-    return super._onDrop(event);
+
+    // Create a Consumable spell scroll on the Inventory tab
+    if (itemData.type === "spell") {
+      const scroll = await Item.implementation.createScrollFromSpell(itemData);
+      return scroll.toObject();
+    }
+
+    // Clean up data
+    this._onDropResetData(itemData);
+
+    // Stack identical consumables
+    const stacked = this._onDropStackConsumables(itemData);
+    if (stacked) return false;
+
+    return itemData;
+  }
+
+  /** @override */
+  _onDropStackConsumables(itemData) {
+    const stacked = super._onDropStackConsumables(itemData); // returns a Promise or null.
+    if (stacked) return stacked;
+
+    const identifier = mythacri.crafting.getIdentifier(new Item.implementation(itemData));
+    if (!identifier) return null;
+    const item = this.document.items.find(i => {
+      const id = mythacri.crafting.getIdentifier(i);
+      return id && (id === identifier);
+    });
+    if (!item) return null;
+    return item.update({"system.quantity": item.system.quantity + Math.max(itemData.system.quantity, 1)});
   }
 
   /** @override */
   activateListeners(html) {
     super.activateListeners(html);
+    html[0].querySelector("[data-action=capacity]").addEventListener("click", this._onConfig.bind(this));
+  }
+
+  /**
+   * Render configuration menu for modifying attributes.
+   * @returns {Promise<Actor5e>}      The updated storage actor.
+   */
+  _onConfig() {
+    const cap = this.document.system.attributes.capacity;
+    const options = {
+      quantity: "DND5E.Quantity",
+      weight: "DND5E.Weight"
+    };
+    const selectOptions = HandlebarsHelpers.selectOptions(options, {hash: {selected: cap.type, localize: true, sort: true}});
+
+    return Dialog.prompt({
+      title: `${game.i18n.localize("MYTHACRI.CapacityConfig")}: ${this.document.name}`,
+      label: game.i18n.localize("Save"),
+      rejectClose: false,
+      content: `
+      <form class="dnd5e">
+        <div class="form-group">
+          <label>${game.i18n.localize("MYTHACRI.CapacityMax")}</label>
+          <div class="form-fields">
+            <input type="number" name="system.attributes.capacity.max" value="${this.document.system.attributes.capacity.max}" autofocus>
+          </div>
+        </div>
+        <div class="form-group">
+          <label>${game.i18n.localize("MYTHACRI.CapacityType")}</label>
+          <div class="form-fields">
+            <select name="system.attributes.capacity.type">${selectOptions}</select>
+          </div>
+        </div>
+      </form>`,
+      callback: ([html]) => {
+        const update = new FormDataExtended(html.querySelector("FORM")).object;
+        return this.document.update(update);
+      }
+    });
+  }
+
+  /** @override */
+  async _onItemDelete(event) {
+    const id = event.currentTarget.closest("[data-item-id]").dataset.itemId;
+    const item = this.document.items.get(id);
+    return item.deleteDialog();
   }
 }

--- a/scripts/modules/applications/storage-sheet.mjs
+++ b/scripts/modules/applications/storage-sheet.mjs
@@ -257,4 +257,14 @@ export class StorageSheet extends dnd5e.applications.actor.ActorSheet5e {
     const item = this.document.items.get(id);
     return item.deleteDialog();
   }
+
+  /** @override */
+  _onItemUse() {
+    return null;
+  }
+
+  /** @override */
+  _onItemContext() {
+    return null;
+  }
 }

--- a/scripts/modules/applications/storage-sheet.mjs
+++ b/scripts/modules/applications/storage-sheet.mjs
@@ -1,0 +1,53 @@
+/**
+ * Actor sheet for storage-type actors.
+ */
+export class StorageSheet extends ActorSheet {
+  /** @override */
+  static get defaultOptions() {
+    const options = super.defaultOptions;
+    options.classes.push("actor", "dnd5e", "storage");
+    options.width = options.height = 600;
+    options.tabs.push({navSelector: ".tabs", contentSelector: ".sheet-body"});
+    return options;
+  }
+
+  /** @override */
+  get template() {
+    return "modules/mythacri-scripts/templates/storage-sheet.hbs";
+  }
+
+  /**
+   * A set of item types that should be prevented from being dropped on this type of actor sheet.
+   * @type {Set<string>}
+   */
+  static unsupportedItemTypes = new Set(["feat", "race", "class", "subclass", "background"]);
+
+  /** @override */
+  async getData(options = {}) {
+    const data = await super.getData(options);
+    return data;
+  }
+
+  /** @override */
+  setPosition(pos = {}) {
+    if (!pos.height) pos.height = "auto";
+    return super.setPosition(pos);
+  }
+
+  /** @override */
+  async _onDrop(event) {
+    const data = TextEditor.getDragEventData(event);
+    if (data.type !== "Item") return;
+    const item = await fromUuid(data.uuid);
+    if (this.unsupportedItemTypes.has(item.type)) {
+      ui.notifications.warn("You cannot drop a", item.type, "onto the storage actor.");
+      return null;
+    }
+    return super._onDrop(event);
+  }
+
+  /** @override */
+  activateListeners(html) {
+    super.activateListeners(html);
+  }
+}

--- a/scripts/modules/applications/storage-sheet.mjs
+++ b/scripts/modules/applications/storage-sheet.mjs
@@ -221,7 +221,9 @@ export class StorageSheet extends dnd5e.applications.actor.ActorSheet5e {
       quantity: "DND5E.Quantity",
       weight: "DND5E.Weight"
     };
-    const selectOptions = HandlebarsHelpers.selectOptions(options, {hash: {selected: cap.type, localize: true, sort: true}});
+    const selectOptions = HandlebarsHelpers.selectOptions(options, {
+      hash: {selected: cap.type, localize: true, sort: true}
+    });
 
     return Dialog.prompt({
       title: `${game.i18n.localize("MYTHACRI.CapacityConfig")}: ${this.document.name}`,
@@ -232,7 +234,7 @@ export class StorageSheet extends dnd5e.applications.actor.ActorSheet5e {
         <div class="form-group">
           <label>${game.i18n.localize("MYTHACRI.CapacityMax")}</label>
           <div class="form-fields">
-            <input type="number" name="system.attributes.capacity.max" value="${this.document.system.attributes.capacity.max}" autofocus>
+            <input type="number" name="system.attributes.capacity.max" value="${cap.max}" autofocus>
           </div>
         </div>
         <div class="form-group">

--- a/scripts/modules/data/crafting.mjs
+++ b/scripts/modules/data/crafting.mjs
@@ -316,7 +316,7 @@ export class Crafting {
     Crafting._characterFlags();
     Object.assign(CONFIG.Item.dataModels, {"mythacri-scripts.recipe": RecipeData});
     DocumentSheetConfig.registerSheet(Item, "mythacri-scripts", RecipeSheet, {
-      types: ["mythacri-scripts.recipe"], makeDefault: true
+      types: ["mythacri-scripts.recipe"], makeDefault: true, label: "MYTHACRI.SheetRecipe"
     });
     loadTemplates(["modules/mythacri-scripts/templates/parts/crafting-recipe.hbs"]);
   }

--- a/scripts/modules/data/crafting.mjs
+++ b/scripts/modules/data/crafting.mjs
@@ -318,7 +318,10 @@ export class Crafting {
     DocumentSheetConfig.registerSheet(Item, "mythacri-scripts", RecipeSheet, {
       types: ["mythacri-scripts.recipe"], makeDefault: true, label: "MYTHACRI.SheetRecipe"
     });
-    loadTemplates(["modules/mythacri-scripts/templates/parts/crafting-recipe.hbs"]);
+    loadTemplates([
+      "modules/mythacri-scripts/templates/parts/crafting-recipe.hbs",
+      "modules/mythacri-scripts/templates/parts/storage-inventory.hbs"
+    ]);
   }
 
   /**

--- a/scripts/modules/data/models/storage-actor.mjs
+++ b/scripts/modules/data/models/storage-actor.mjs
@@ -1,24 +1,48 @@
-import {StorageSheet} from "../../applications/storage-sheet.mjs";
-
 /**
  * Data model for `storage` actors.
  * @property {object} currency
  * @property {object} capacity
  * @property {}
  */
-export class StorageData extends dnd5e.dataModels.SystemDataModel.mixin() {
+export class StorageData extends dnd5e.dataModels.SystemDataModel.mixin(
+  dnd5e.dataModels.shared.CurrencyTemplate
+) {
   /** @override */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      currency: {},
-      capacity: {}
+      attributes: new foundry.data.fields.SchemaField({
+        capacity: new foundry.data.fields.SchemaField({
+          max: new foundry.data.fields.NumberField({positive: true, integer: true, initial: 100}),
+          type: new foundry.data.fields.StringField({required: true, initial: "quantity"})
+        })
+      })
     });
   }
 
-  static init() {
-    Object.assign(CONFIG.Item.dataModels, {"mythacri-scripts.storage": StorageData});
-    DocumentSheetConfig.registerSheet(Actor, "mythacri-scripts", StorageSheet, {
-      types: ["mythacri-scripts.storage"], makeDefault: true, label: "MYTHACRI.SheetStorage"
+  /** @override */
+  prepareDerivedData() {
+    const cap = this.attributes.capacity;
+    const isQty = cap.type === "quantity";
+    const total = this.parent.items.reduce((acc, item) => {
+      if (isQty) return acc + (item.system.quantity || 0);
+      return acc + (item.system.weight || 0) * (item.system.quantity || 0);
+    }, 0);
+    this.attributes.capacity.value = Math.round(total);
+    this.attributes.capacity.pct = Math.round(Math.clamped(total / this.attributes.capacity.max, 0, 1) * 100);
+    this.attributes.capacity.overflow = total > this.attributes.capacity.max;
+  }
+
+  /** @override */
+  async _preCreate(data, options, user) {
+    const actor = this.parent;
+    actor.updateSource({
+      prototypeToken: {
+        actorLink: true,
+        "bar1.attribute": null,
+        disposition: CONST.TOKEN_DISPOSITIONS.FRIENDLY,
+        displayName: CONST.TOKEN_DISPLAY_MODES.NONE,
+        displayBars: CONST.TOKEN_DISPLAY_MODES.NONE
+      }
     });
   }
 }

--- a/scripts/modules/data/models/storage-actor.mjs
+++ b/scripts/modules/data/models/storage-actor.mjs
@@ -1,0 +1,24 @@
+import {StorageSheet} from "../../applications/storage-sheet.mjs";
+
+/**
+ * Data model for `storage` actors.
+ * @property {object} currency
+ * @property {object} capacity
+ * @property {}
+ */
+export class StorageData extends dnd5e.dataModels.SystemDataModel.mixin() {
+  /** @override */
+  static defineSchema() {
+    return this.mergeSchema(super.defineSchema(), {
+      currency: {},
+      capacity: {}
+    });
+  }
+
+  static init() {
+    Object.assign(CONFIG.Item.dataModels, {"mythacri-scripts.storage": StorageData});
+    DocumentSheetConfig.registerSheet(Actor, "mythacri-scripts", StorageSheet, {
+      types: ["mythacri-scripts.storage"], makeDefault: true, label: "MYTHACRI.SheetStorage"
+    });
+  }
+}

--- a/scripts/modules/data/storage.mjs
+++ b/scripts/modules/data/storage.mjs
@@ -1,0 +1,35 @@
+import {StorageSheet} from "../applications/storage-sheet.mjs";
+import {StorageData} from "./models/storage-actor.mjs";
+
+export class Storage {
+  /** Initialize module. */
+  static init() {
+    Object.assign(CONFIG.Actor.dataModels, {"mythacri-scripts.storage": StorageData});
+    DocumentSheetConfig.registerSheet(Actor, "mythacri-scripts", StorageSheet, {
+      types: ["mythacri-scripts.storage"], makeDefault: true, label: "MYTHACRI.SheetStorage"
+    });
+    Hooks.on("preCreateActiveEffect", Storage._cancelEffectCreation);
+    Storage._patchActor();
+  }
+
+  /**
+   * Prevent creation of ActiveEffects on the storage actor.
+   * @param {ActiveEffect5e} effect     The effect to be created.
+   * @param {object} context            Options that modify the creation.
+   */
+  static _cancelEffectCreation(effect) {
+    if (effect.parent?.type === "mythacri-scripts.storage") return false;
+  }
+
+  /**
+   * Patch the default Actor5e class due to roll data issues.
+   */
+  static _patchActor() {
+    CONFIG.Actor.documentClass = class Actor5e extends CONFIG.Actor.documentClass {
+      getRollData({deterministic = false} = {}) {
+        if (this.type === "mythacri-scripts.storage") return {...this.system};
+        return super.getRollData({deterministic});
+      }
+    }
+  }
+}

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -8,6 +8,7 @@ import {Soundboard} from "./modules/applications/soundboard.mjs";
 import {Encounter} from "./modules/data/encounter.mjs";
 import {ExperiencePips} from "./modules/data/pips.mjs";
 import {Concentration} from "./modules/data/concentration.mjs";
+import {StorageData} from "./modules/data/models/storage-actor.mjs";
 
 Hooks.once("init", SystemConfig.init);
 Hooks.once("init", PublicInterface.init);
@@ -19,3 +20,4 @@ Hooks.once("init", Soundboard.init);
 Hooks.once("init", Encounter.init);
 Hooks.once("init", ExperiencePips.init);
 Hooks.once("init", Concentration.init);
+Hooks.once("init", StorageData.init);

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -8,7 +8,7 @@ import {Soundboard} from "./modules/applications/soundboard.mjs";
 import {Encounter} from "./modules/data/encounter.mjs";
 import {ExperiencePips} from "./modules/data/pips.mjs";
 import {Concentration} from "./modules/data/concentration.mjs";
-import {StorageData} from "./modules/data/models/storage-actor.mjs";
+import {Storage} from "./modules/data/storage.mjs";
 
 Hooks.once("init", SystemConfig.init);
 Hooks.once("init", PublicInterface.init);
@@ -20,4 +20,4 @@ Hooks.once("init", Soundboard.init);
 Hooks.once("init", Encounter.init);
 Hooks.once("init", ExperiencePips.init);
 Hooks.once("init", Concentration.init);
-Hooks.once("init", StorageData.init);
+Hooks.once("init", Storage.init);

--- a/styles/mythacri.css
+++ b/styles/mythacri.css
@@ -545,3 +545,13 @@
   padding: 0 1em;
   margin: 1em 0;
 }
+
+/* ------------------------------ */
+/*                                */
+/*         STORAGE SHEET          */
+/*                                */
+/* ------------------------------ */
+.sheet.actor.dnd5e.storage {
+  min-width: 600px;
+  min-height: 600px;
+}

--- a/styles/mythacri.css
+++ b/styles/mythacri.css
@@ -553,5 +553,35 @@
 /* ------------------------------ */
 .sheet.actor.dnd5e.storage {
   min-width: 600px;
-  min-height: 600px;
+  min-height: 800px;
+}
+.sheet.actor.dnd5e.storage .header-details {
+  height: calc(100% - 10px);
+  padding: 5px;
+  margin: 0;
+}
+.sheet.actor.dnd5e.storage .sheet-header .charname {
+  position: relative;
+  height: 100%;
+}
+.sheet.actor.dnd5e.storage .sheet-header .charname input {
+  height: 100%;
+  margin: 0;
+  width: calc(100% - 50px);
+}
+.sheet.actor.dnd5e.storage .charname .config-button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 4px;
+  font-size: 16px;
+  display: none;
+}
+.sheet.actor.dnd5e.storage .charname:hover .config-button {
+  display: block;
+}
+.sheet.actor.dnd5e.storage .sheet-header img.profile {
+  flex: 0 0 100px;
+  max-width: 100px;
+  height: 100px;
 }

--- a/templates/parts/storage-inventory.hbs
+++ b/templates/parts/storage-inventory.hbs
@@ -1,0 +1,83 @@
+{{#if showCurrency}}
+<div class="inventory-filters flexrow">
+  <ol class="currency flexrow">
+    <h3>{{localize "DND5E.Currency"}}</h3>
+    {{#each system.currency as |v k|}}
+    <label class="denomination {{k}}">{{ lookup ../labels.currencies k}}</label>
+    <input type="text" name="system.currency.{{k}}" value="{{v}}" data-dtype="Number">
+    {{/each}}
+  </ol>
+</div>
+{{/if}}
+
+<ol class="items-list inventory-list">
+  {{#each sections as |section sid|}}
+  <li class="items-header flexrow">
+    <h3 class="item-name flexrow">{{localize section.label}}</h3>
+    <div class="item-detail item-quantity">{{localize "DND5E.QuantityAbbr"}}</div>
+    <div class="item-detail item-uses">{{localize "DND5E.Charges"}}</div>
+    <div class="item-detail item-action">{{localize "DND5E.Usage"}}</div>
+    {{#if @root.owner}}<div class="item-controls flexrow"></div>{{/if}}
+  </li>
+
+  <ol class="item-list">
+    {{#each section.items as |item iid|}}
+    {{#dnd5e-itemContext item as |ctx|}}
+    <li class="item flexrow {{section.css}} {{#if ctx.isExpanded}}expanded{{/if}}" data-item-id="{{item.id}}">
+      <div class="item-name flexrow {{@root.rollableClass}}">
+        <div class="item-image" tabindex="0" role="button" aria-label="{{item.name}}"
+          style="background-image: url('{{item.img}}')"></div>
+        <h4>
+          {{item.name~}}
+          {{~#if ctx.isStack}} ({{item.system.quantity}}){{/if}}
+        </h4>
+      </div>
+
+      <div class="item-detail item-quantity">
+        <input type="text" value="{{item.system.quantity}}" placeholder="0" data-dtype="Number"
+          data-name="system.quantity">
+      </div>
+
+      <div class="item-detail item-uses">
+        {{#if ctx.hasUses }}
+        <input type="text" value="{{item.system.uses.value}}" placeholder="0" data-dtype="Number"
+          data-name="system.uses.value">
+        / {{item.system.uses.max}}
+        {{/if}}
+      </div>
+
+      <div class="item-detail item-action">
+        {{#if item.system.activation.type }}
+        {{item.labels.activation}}
+        {{/if}}
+      </div>
+
+      {{#if @root.owner}}
+      <div class="item-controls flexrow">
+        <a class="item-control item-edit" data-action="itemEdit" data-tooltip="DND5E.ItemEdit">
+          <i class="fas fa-edit"></i>
+        </a>
+        <a class="item-control item-delete" data-action="itemDelete" data-tooltip="DND5E.ItemDelete">
+          <i class="fas fa-trash"></i>
+        </a>
+      </div>
+      {{/if}}
+
+      {{#if ctx.isExpanded}}
+      {{> "dnd5e.item-summary" (lookup @root.expandedData item.id)}}
+      {{/if}}
+    </li>
+    {{/dnd5e-itemContext}}
+    {{/each}}
+  </ol>
+  {{/each}}
+</ol>
+
+<div class="encumbrance {{#if system.attributes.capacity.overflow}}encumbered{{/if}}">
+  <span class="encumbrance-bar" style="width:{{system.attributes.capacity.pct}}%"></span>
+  <span class="encumbrance-label">{{system.attributes.capacity.value}} / {{system.attributes.capacity.max}}</span>
+  <i class="encumbrance-breakpoint encumbrance-33 arrow-up"></i>
+  <i class="encumbrance-breakpoint encumbrance-33 arrow-down"></i>
+  <i class="encumbrance-breakpoint encumbrance-66 arrow-up"></i>
+  <i class="encumbrance-breakpoint encumbrance-66 arrow-down"></i>
+</div>

--- a/templates/storage-sheet.hbs
+++ b/templates/storage-sheet.hbs
@@ -1,0 +1,24 @@
+<form class="{{cssClass}} flexcol" autocomplete="off">
+
+  {{!-- Sheet Header --}}
+  <header class="sheet-header flexrow">
+    <img class="profile" src="{{actor.img}}" data-tooltip="{{actor.name}}" data-edit="img">
+
+    <section class="header-details flexrow">
+      <h1 class="charname"><input name="name" type="text" value="{{actor.name}}" placeholder="{{ localize 'DND5E.Name' }}"></h1>
+    </section>
+  </header>
+
+  {{!-- Sheet Navigation --}}
+  <nav class="sheet-navigation tabs" data-group="primary">
+    <a class="item" data-tab="inventory">{{ localize "DND5E.Inventory" }}</a>
+  </nav>
+
+  {{!-- Sheet Body --}}
+  <section class="sheet-body">
+    {{!-- Inventory Tab --}}
+    <div class="tab inventory flexcol" data-group="primary" data-tab="inventory">
+      {{> "dnd5e.actor-inventory" sections=inventory}}
+    </div>
+  </section>
+</form>

--- a/templates/storage-sheet.hbs
+++ b/templates/storage-sheet.hbs
@@ -3,22 +3,37 @@
   {{!-- Sheet Header --}}
   <header class="sheet-header flexrow">
     <img class="profile" src="{{actor.img}}" data-tooltip="{{actor.name}}" data-edit="img">
-
     <section class="header-details flexrow">
-      <h1 class="charname"><input name="name" type="text" value="{{actor.name}}" placeholder="{{ localize 'DND5E.Name' }}"></h1>
+      <h1 class="charname">
+        <input name="name" type="text" value="{{actor.name}}" placeholder="{{ localize 'DND5E.Name' }}">
+        <a class="config-button" data-action="capacity" data-tooltip="MYTHACRI.CapacityConfig">
+          <i class="fas fa-cog"></i>
+        </a>
+      </h1>
     </section>
   </header>
 
   {{!-- Sheet Navigation --}}
   <nav class="sheet-navigation tabs" data-group="primary">
-    <a class="item" data-tab="inventory">{{ localize "DND5E.Inventory" }}</a>
+    <a class="item" data-tab="gear">{{ localize "MYTHACRI.StorageTabGear" }}</a>
+    <a class="item" data-tab="consumables">{{ localize "MYTHACRI.StorageTabConsumables" }}</a>
+    <a class="item" data-tab="loot">{{ localize "MYTHACRI.StorageTabLoot" }}</a>
+    <a class="item" data-tab="resources">{{ localize "MYTHACRI.StorageTabResources" }}</a>
   </nav>
 
   {{!-- Sheet Body --}}
   <section class="sheet-body">
-    {{!-- Inventory Tab --}}
-    <div class="tab inventory flexcol" data-group="primary" data-tab="inventory">
-      {{> "dnd5e.actor-inventory" sections=inventory}}
+    <div class="tab inventory flexcol" data-group="primary" data-tab="gear">
+      {{> "modules/mythacri-scripts/templates/parts/storage-inventory.hbs" sections=gear showCurrency=false}}
+    </div>
+    <div class="tab inventory flexcol" data-group="primary" data-tab="consumables">
+      {{> "modules/mythacri-scripts/templates/parts/storage-inventory.hbs" sections=consumables showCurrency=false}}
+    </div>
+    <div class="tab inventory flexcol" data-group="primary" data-tab="loot">
+      {{> "modules/mythacri-scripts/templates/parts/storage-inventory.hbs" sections=loot showCurrency=true}}
+    </div>
+    <div class="tab inventory flexcol" data-group="primary" data-tab="resources">
+      {{> "modules/mythacri-scripts/templates/parts/storage-inventory.hbs" sections=resources showCurrency=false}}
     </div>
   </section>
 </form>


### PR DESCRIPTION
- Creates `mythacri-scripts.storage` system actor type, with associated sheet.
- The actor will not allow for class, subclass, or any other items that do not have a quantity.
- Dropping a spell onto the sheet anywhere will create a scroll.
- Dropping consumables will stack, as usual.
- Dropping loot will not stack.
- Dropping loot that is a crafting resource *will* stack.
- The actor can be configured to track capacity in quantity or weight.

Closes #133.