### PR TITLE
[#139] Storage actor sheet tweaks

### DIFF
--- a/templates/parts/storage-inventory.hbs
+++ b/templates/parts/storage-inventory.hbs
@@ -15,8 +15,8 @@
   <li class="items-header flexrow">
     <h3 class="item-name flexrow">{{localize section.label}}</h3>
     <div class="item-detail item-quantity">{{localize "DND5E.QuantityAbbr"}}</div>
-    <div class="item-detail item-uses">{{localize "DND5E.Charges"}}</div>
-    <div class="item-detail item-action">{{localize "DND5E.Usage"}}</div>
+    {{#unless ../hideUses}}<div class="item-detail item-uses">{{localize "DND5E.Charges"}}</div>{{/unless}}
+    {{#unless ../hideAction}}<div class="item-detail item-action">{{localize "DND5E.Usage"}}</div>{{/unless}}
     {{#if @root.owner}}<div class="item-controls flexrow"></div>{{/if}}
   </li>
 
@@ -38,6 +38,7 @@
           data-name="system.quantity">
       </div>
 
+      {{#unless ../../hideUses}}
       <div class="item-detail item-uses">
         {{#if ctx.hasUses }}
         <input type="text" value="{{item.system.uses.value}}" placeholder="0" data-dtype="Number"
@@ -45,12 +46,15 @@
         / {{item.system.uses.max}}
         {{/if}}
       </div>
+      {{/unless}}
 
+      {{#unless ../../hideAction}}
       <div class="item-detail item-action">
         {{#if item.system.activation.type }}
         {{item.labels.activation}}
         {{/if}}
       </div>
+      {{/unless}}
 
       {{#if @root.owner}}
       <div class="item-controls flexrow">

--- a/templates/storage-sheet.hbs
+++ b/templates/storage-sheet.hbs
@@ -30,10 +30,10 @@
       {{> "modules/mythacri-scripts/templates/parts/storage-inventory.hbs" sections=consumables showCurrency=false}}
     </div>
     <div class="tab inventory flexcol" data-group="primary" data-tab="loot">
-      {{> "modules/mythacri-scripts/templates/parts/storage-inventory.hbs" sections=loot showCurrency=true}}
+      {{> "modules/mythacri-scripts/templates/parts/storage-inventory.hbs" sections=loot showCurrency=true hideUses=true hideAction=true}}
     </div>
     <div class="tab inventory flexcol" data-group="primary" data-tab="resources">
-      {{> "modules/mythacri-scripts/templates/parts/storage-inventory.hbs" sections=resources showCurrency=false}}
+      {{> "modules/mythacri-scripts/templates/parts/storage-inventory.hbs" sections=resources showCurrency=false hideUses=true hideAction=true}}
     </div>
   </section>
 </form>


### PR DESCRIPTION
- Remove some unneeded leftover code.
- Sort items, first by `sort` then by `name`.
- Prevent rendering multiple configs.
- Remove charges and action columns from loot/resource tabs.