### PR TITLE
[#113] Implement character flag for Peak Physical Condition

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -230,6 +230,8 @@
   "MYTHACRI.CapacityMax": "Max Capacity",
   "MYTHACRI.CapacityType": "Capacity Type",
   "MYTHACRI.CapacityConfig": "Modify Attributes",
+  "MYTHACRI.FlagsPeakPhysicalName": "Peak Physical Condition",
+  "MYTHACRI.FlagsPeakPhysicalHint": "Remove an additional level of exhaustion on a long rest, and recover all hit dice.",
   "TYPES.Actor.mythacri-scripts.storage": "Storage",
   "TYPES.Item.mythacri-scripts.recipe": "Recipe"
 }

--- a/scripts/modules/data/resting.mjs
+++ b/scripts/modules/data/resting.mjs
@@ -23,8 +23,17 @@ export class Resting {
   static preRestCompleted(actor, result) {
     if (result.longRest) {
       const exh = actor.system.attributes.exhaustion;
-      result.updateData["system.attributes.exhaustion"] = Math.max(exh - 1, 0);
+      const isPeak = actor.flags.dnd5e?.peakPhysical ?? false;
+      result.updateData["system.attributes.exhaustion"] = Math.max(exh - (isPeak ? 2 : 1), 0);
       delete result.updateData["system.attributes.hp.value"];
+      if (!isPeak) return;
+      result.dhd = 0;
+      for (const cls of Object.values(actor.classes)) {
+        result.dhd += cls.system.hitDiceUsed;
+        const existing = result.updateItems.find(upd => upd._id === cls.id);
+        if (existing) existing["system.hitDiceUsed"] = 0;
+        else result.updateItems.push({_id: cls.id, "system.hitDiceUsed": 0});
+      }
     }
   }
 

--- a/scripts/modules/system-config.mjs
+++ b/scripts/modules/system-config.mjs
@@ -10,6 +10,7 @@ export class SystemConfig {
     SystemConfig._conditions();
     SystemConfig._currencies();
     SystemConfig._consumableTypes();
+    SystemConfig._characterFlags();
   }
 
   static _featureTypes() {
@@ -206,5 +207,14 @@ export class SystemConfig {
   static _consumableTypes() {
     CONFIG.DND5E.consumableTypes.rune = "MYTHACRI.ConsumableRune";
     CONFIG.DND5E.consumableTypes.spirit = "MYTHACRI.ConsumableSpirit";
+  }
+
+  static _characterFlags() {
+    CONFIG.DND5E.characterFlags.peakPhysical = {
+      hint: "MYTHACRI.FlagsPeakPhysicalHint",
+      name: "MYTHACRI.FlagsPeakPhysicalName",
+      section: "DND5E.Feats",
+      type: Boolean
+    };
   }
 }


### PR DESCRIPTION
This implements a flag found in Special Traits.
If toggled on, an actor will, on a long rest,
- remove 2 levels of exhaustion, instead of 1. This does not affect full rests, which still removes 3.
- recover all spent hit dice, instead of only half.

Closes #113.