### PR TITLE
[#154] Top-left align background and allow for recipe list to scroll again

### DIFF
--- a/styles/mythacri.css
+++ b/styles/mythacri.css
@@ -238,7 +238,7 @@
         overflow: hidden;
         gap: 1em;
         padding-top: 10px;
-        background: transparent url(../../../ui/parchment.jpg) repeat 50% 50%;
+        background: transparent url(../../../ui/parchment.jpg) repeat;
         background-blend-mode: color-dodge;
         padding-bottom: 5px;
         flex: 1;
@@ -246,7 +246,7 @@
         .recipes {
           overflow: auto;
           margin-left: 5px;
-          margin-top: auto;
+          height: 100%;
 
           .recipe {
             border-top: 3px inset;


### PR DESCRIPTION
Closes #154.

Sets a height on the recipe list. This has the side effect of making it glued to the top.

The background also had a weird issue where it would shuffle about when the UI was resized. This sets its origin to be the top left so it looks smoother.