### PR TITLE
[#170] Fix dazed and impaired duplication

### DIFF
--- a/scripts/modules/applications/crafting-application.mjs
+++ b/scripts/modules/applications/crafting-application.mjs
@@ -453,7 +453,7 @@ class CraftingHandler extends dnd5e.applications.DialogMixin(Application) {
           <fieldset><legend>${target.name}</legend>${target.system.description.value}</fieldset>`
         },
         quantity: 1,
-        weight: 0,
+        weight: {value: 0},
         rarity: {
           1: "common",
           2: "uncommon",

--- a/scripts/modules/applications/runes-config.mjs
+++ b/scripts/modules/applications/runes-config.mjs
@@ -95,6 +95,7 @@ export class RunesConfig extends Application {
    */
   async _onClickToggle(event) {
     const id = event.currentTarget.closest("[data-bonus-id]").dataset.bonusId;
-    return babonus.toggleBonus(this.item, id);
+    const bonus = babonus.getCollection(this.item).get(id);
+    bonus.toggle();
   }
 }

--- a/scripts/modules/data/crafting.mjs
+++ b/scripts/modules/data/crafting.mjs
@@ -456,11 +456,11 @@ export class Crafting {
 
   /**
    * Utility function for the template data of the triple dropdowns for resource items.
-   * @param {object} data                 Flag data.
-   * @param {string} data.type            The stored type.
-   * @param {string} data.subtype         The stored subtype.
-   * @param {string} data.subsubtype      The stored sub-subtype.
-   * @param {number} data.grade           A stored spirit grade.
+   * @param {object} [data]                 Flag data.
+   * @param {string} [data.type]            The stored type.
+   * @param {string} [data.subtype]         The stored subtype.
+   * @param {string} [data.subsubtype]      The stored sub-subtype.
+   * @param {number} [data.grade]           A stored spirit grade.
    * @returns {object}
    */
   static getTemplateData(data = {}) {
@@ -591,7 +591,7 @@ export class Crafting {
    * Set up character flags for opting into crafting types.
    */
   static _characterFlags() {
-    for (const key in Crafting.recipeTypes) {
+    for (const key of Object.keys(Crafting.recipeTypes)) {
       const label = key.capitalize();
       CONFIG.DND5E.characterFlags[`crafting.${key}`] = {
         name: `MYTHACRI.CraftingSection${label}`,

--- a/scripts/modules/data/encounter.mjs
+++ b/scripts/modules/data/encounter.mjs
@@ -23,7 +23,7 @@ export class Encounter extends Application {
     const users = game.users.reduce((acc, user) => {
       if (!user.active || user.isGM) return acc;
       const total = this.users?.[user.id];
-      for(const roll of rolls) if(roll.value === total) roll.match = true;
+      for (const roll of rolls) if (roll.value === total) roll.match = true;
       acc.push({
         user: user,
         total: total ?? null,
@@ -82,7 +82,7 @@ export class Encounter extends Application {
    * @returns {Promise<ChatMessage>}
    */
   async prompt() {
-    return ChatMessage.create({
+    return ChatMessage.implementation.create({
       content: await renderTemplate("modules/mythacri-scripts/templates/encounter-prompt.hbs", {
         amount: game.settings.get(MODULE.ID, "encounter-dice")
       })

--- a/scripts/modules/data/models/recipe-item.mjs
+++ b/scripts/modules/data/models/recipe-item.mjs
@@ -1,6 +1,8 @@
 import {MODULE} from "../../constants.mjs";
 import {Crafting} from "../crafting.mjs";
 
+const {SchemaField, StringField, NumberField, ArrayField, BooleanField} = foundry.data.fields;
+
 /**
  * Data model for `recipe` items.
  * @property {object} type
@@ -26,23 +28,23 @@ export class RecipeData extends dnd5e.dataModels.SystemDataModel.mixin(
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
       type: new dnd5e.dataModels.item.ItemTypeField({subtype: false, baseItem: false}),
-      crafting: new foundry.data.fields.SchemaField({
-        target: new foundry.data.fields.SchemaField({
-          uuid: new foundry.data.fields.StringField({required: true}),
-          quantity: new foundry.data.fields.NumberField({integer: true, min: 1, initial: 1})
+      crafting: new SchemaField({
+        target: new SchemaField({
+          uuid: new StringField({required: true}),
+          quantity: new NumberField({integer: true, min: 1, initial: 1})
         }),
-        components: new foundry.data.fields.ArrayField(new foundry.data.fields.SchemaField({
-          identifier: new foundry.data.fields.StringField({required: true}),
-          quantity: new foundry.data.fields.NumberField({integer: true, min: 1, initial: 1})
+        components: new ArrayField(new SchemaField({
+          identifier: new StringField({required: true}),
+          quantity: new NumberField({integer: true, min: 1, initial: 1})
         })),
-        basic: new foundry.data.fields.BooleanField()
+        basic: new BooleanField()
       }),
-      rarity: new foundry.data.fields.StringField({required: true, blank: true, label: "DND5E.Rarity"}),
-      price: new foundry.data.fields.SchemaField({
-        value: new foundry.data.fields.NumberField({
+      rarity: new StringField({required: true, blank: true, label: "DND5E.Rarity"}),
+      price: new SchemaField({
+        value: new NumberField({
           required: true, nullable: false, initial: 0, min: 0, label: "DND5E.Price"
         }),
-        denomination: new foundry.data.fields.StringField({
+        denomination: new StringField({
           required: true, blank: false, initial: "gp", label: "DND5E.Currency"
         })
       }, {label: "DND5E.Price"}),

--- a/scripts/modules/data/models/resource-populator.mjs
+++ b/scripts/modules/data/models/resource-populator.mjs
@@ -1,15 +1,16 @@
 import {Crafting} from "../crafting.mjs";
 
+const {SchemaField, BooleanField, StringField} = foundry.data.fields;
+
 /** Utility model for holding and refreshing data when creating loot on an actor. */
 export class ResourcePopulatorModel extends foundry.abstract.DataModel {
   /** @override */
   static defineSchema() {
-    const fields = foundry.data.fields;
     return {
-      types: new fields.SchemaField(Object.entries(Crafting.subsubtypes).reduce((acc, [key, {label}]) => {
-        acc[key] = new fields.SchemaField({
-          active: new fields.BooleanField({initial: true}),
-          formula: new fields.StringField({initial: "1d2", required: true}),
+      types: new SchemaField(Object.entries(Crafting.subsubtypes).reduce((acc, [key, {label}]) => {
+        acc[key] = new SchemaField({
+          active: new BooleanField({initial: true}),
+          formula: new StringField({initial: "1d2", required: true}),
         }, {label: label});
         return acc;
       }, {}))

--- a/scripts/modules/data/models/storage-actor.mjs
+++ b/scripts/modules/data/models/storage-actor.mjs
@@ -1,3 +1,5 @@
+const {SchemaField, NumberField, StringField} = foundry.data.fields;
+
 /**
  * Data model for `storage` actors.
  * @property {object} currency
@@ -10,10 +12,10 @@ export class StorageData extends dnd5e.dataModels.SystemDataModel.mixin(
   /** @override */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      attributes: new foundry.data.fields.SchemaField({
-        capacity: new foundry.data.fields.SchemaField({
-          max: new foundry.data.fields.NumberField({positive: true, integer: true, initial: 100}),
-          type: new foundry.data.fields.StringField({required: true, initial: "quantity"})
+      attributes: new SchemaField({
+        capacity: new SchemaField({
+          max: new NumberField({positive: true, integer: true, initial: 100}),
+          type: new StringField({required: true, initial: "quantity"})
         })
       })
     });

--- a/scripts/modules/system-config.mjs
+++ b/scripts/modules/system-config.mjs
@@ -233,11 +233,13 @@ export class SystemConfig {
     for (const [k, v] of Object.entries(effects)) {
       CONFIG.statusEffects.push({
         id: k,
+        _id: dnd5e.utils.staticID(`dnd5e${k}`),
         name: v.label,
-        icon: v.icon,
+        img: v.icon,
         reference: v.reference
       });
-      CONFIG.DND5E.conditionTypes[k] = v;
+      CONFIG.DND5E.conditionTypes[k] = {...v, pseudo: false};
+      CONFIG.DND5E.statusEffects[k] = {name: v.label, icon: v.icon};
     }
 
     // Modify exhaustion.


### PR DESCRIPTION
This fixes dazed and impaired being non-unique, and add some v12 fixes and improvements.

Before, repeated clicks on the Dazed or Impaired condition through the Character Sheet would create multiples of the conditions due to a missing `_id` property. This should no longer be the case.

Also added some fixes for migrated schemas as well as styling issues.

Closes #170.

This PR cannot be reviewed unless you are on v3.2.x of the dnd5e system and on Foundry v12.