### PR TITLE
[#176] Set global illumination on by default

### DIFF
--- a/scripts/modules/game-config.mjs
+++ b/scripts/modules/game-config.mjs
@@ -1,0 +1,20 @@
+export default class GameConfig {
+  /** Initialize module. */
+  static init() {
+    Hooks.on("preCreateScene", GameConfig.preCreateScene);
+  }
+
+  /**
+   * Adjust default scene configuration.
+   * @param {Scene} scene           The scene to be created.
+   * @param {object} sceneData      The data given for the creation.
+   * @param {object} options        The scene creation options.
+   * @param {string} userId         The id of the user creating the scene.
+   */
+  static preCreateScene(scene, sceneData, options, userId) {
+    const globalLight = sceneData.environment?.globalLight ?? {};
+    const update = {};
+    if (!("enabled" in globalLight)) update["environment.globalLight.enabled"] = true;
+    scene.updateSource(update);
+  }
+}

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -11,6 +11,7 @@ import {CombatEnhancement} from "./modules/data/combat.mjs";
 import {Storage} from "./modules/data/storage.mjs";
 import {Auras} from "./modules/data/token-auras.mjs";
 import {ItemTransfer} from "./modules/data/item-transfer.mjs";
+import GameConfig from "./modules/game-config.mjs";
 
 Hooks.once("init", SystemConfig.init);
 Hooks.once("init", PublicInterface.init);
@@ -25,3 +26,4 @@ Hooks.once("init", CombatEnhancement.init);
 Hooks.once("init", Storage.init);
 Hooks.once("init", Auras.init);
 Hooks.once("init", ItemTransfer.init);
+Hooks.once("init", GameConfig.init);


### PR DESCRIPTION
Adds a `GameConfig` class mirroring the system config, to house all changes to Core itself.

Currently adds only the one change in #176; setting the 'Global Illumination' box to enabled by default when creating a scene - this is unless data is specifically passed into the creation with a value in this field.

This requires v12 due to changes in the data structure of `Scene` documents which this PR matches.

Closes #176.