### PR TITLE
[#184] Feral regression meter

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -88,6 +88,8 @@
   "MYTHACRI.FeatureWitchCurse": "Witch's Curse",
   "MYTHACRI.FeatureWitchGrandHex": "Grand Hex",
   "MYTHACRI.FeatureWitchHex": "Hex",
+  "MYTHACRI.FlagsFeralRegression": "Feral Regression",
+  "MYTHACRI.FlagsFeralRegressionHint": "Whether this actor make use of Feral Regression, implementing a bar underneath hit dice on their sheet to keep track of the value.",
   "MYTHACRI.FlagsPeakPhysical": "Peak Physical Condition",
   "MYTHACRI.FlagsPeakPhysicalHint": "Remove an additional level of exhaustion on a long rest, and recover all hit dice.",
   "MYTHACRI.FreeLongRestHeal": "Free Heal",

--- a/scripts/modules/data/combat.mjs
+++ b/scripts/modules/data/combat.mjs
@@ -3,7 +3,10 @@ export class CombatEnhancement {
   static init() {
     CombatEnhancement.pugilist();
     CombatEnhancement.animatePause();
+    CombatEnhancement.feralRegression();
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Replace the first die of a pugilist weapon with a higher face if applicable.
@@ -27,6 +30,8 @@ export class CombatEnhancement {
     });
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Is this item a valid pugilist weapon?
    * @param {Item5e} item     An item that rolls damage.
@@ -40,6 +45,8 @@ export class CombatEnhancement {
     const isImprovised = item.system.type.value === "improv";
     return isSimpleM || isWhip || isImprovised;
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Bounce the pause image when the game is paused.
@@ -55,6 +62,59 @@ export class CombatEnhancement {
       ];
       const options = {duration: 2000, iterations: 1, easing: "cubic-bezier(0.8, 2, 0, 1)"};
       html.animate(frames, options);
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Add a Feral Regression meter to character sheets.
+   */
+  static feralRegression() {
+    Hooks.on("renderActorSheet5eCharacter2", (sheet, [html]) => {
+      const enabled = sheet.document.getFlag("dnd5e", "feralRegression");
+      if (!enabled) return;
+
+      let value = sheet.document.getFlag("mythacri-scripts", "feralRegression");
+      if (!value) value = 0;
+
+      const negative = value < 0 ? Math.abs(value) : 0;
+      const negPct = Math.round(negative / 5 * 100) + "%";
+      const positive = value > 0 ? value : 0;
+      const posPct = Math.round(positive / 5 * 100) + "%";
+
+      const css = "meter feral-regression progress";
+      const attributes = Object.entries({
+        role: "meter",
+        "aria-valuemin": "0",
+        "aria-valuemax": "5"
+      }).map(([k, v]) => `${k}="${v}"`).join(" ");
+
+      const template = `
+      <div class="meter-group feral-regression">
+        <div class="label roboto-condensed-upper">
+          <span>${game.i18n.localize("MYTHACRI.FlagsFeralRegression")}</span>
+        </div>
+        <div class="meters">
+          <div class="${css} negative" ${attributes} aria-valuenow="${negative}" style="--bar-percentage: ${negPct}">
+            <div class="label">${negative ? "&minus;" + negative : ""}</div>
+          </div>
+          <div class="${css} positive" ${attributes} aria-valuenow="${positive}" style="--bar-percentage: ${posPct}">
+            <div class="label">${positive ? "&plus;" + positive : ""}</div>
+          </div>
+        </div>
+      </div>`;
+
+      const div = document.createElement("DIV");
+      div.innerHTML = template;
+
+      div.querySelectorAll(".meters > .meter").forEach(element => element.addEventListener("click", event => {
+        const t = event.currentTarget;
+        const delta = t.classList.contains("positive") ? 1 : -1;
+        return sheet.document.setFlag("mythacri-scripts", "feralRegression", Math.clamp(value + delta, -5, 5));
+      }));
+
+      html.querySelector(".meter-group").parentElement.insertAdjacentElement("beforeend", div.firstElementChild);
     });
   }
 }

--- a/scripts/modules/system-config.mjs
+++ b/scripts/modules/system-config.mjs
@@ -288,5 +288,12 @@ export class SystemConfig {
       section: "DND5E.Feats",
       type: Boolean
     };
+
+    CONFIG.DND5E.characterFlags.feralRegression = {
+      name: "MYTHACRI.FlagsFeralRegression",
+      hint: "MYTHACRI.FlagsFeralRegressionHint",
+      section: "DND5E.RacialTraits",
+      type: Boolean
+    };
   }
 }

--- a/styles/mythacri.css
+++ b/styles/mythacri.css
@@ -55,6 +55,46 @@
   .sheet-body .pills-group .pill > i.coldIron::before {
     content: "\f6fc";
   }
+
+  /* Feral Regression */
+  .feral-regression {
+    .meters {
+      display: flex;
+
+      .meter.feral-regression {
+        flex: 1;
+        height: 25px;
+        font-size: var(--font-size-14);
+        cursor: pointer;
+
+        &::before {
+          background: linear-gradient(to right, rgb(57, 0, 68) 0%, rgb(128, 0, 117) 100%);
+          border-inline-end: calc(var(--border-width) / 2) solid rgb(121, 65, 121);
+        }
+
+        &.negative {
+          border-right: none;
+          border-bottom-right-radius: 0;
+          border-top-right-radius: 0;
+
+          &::before {
+            transform: scaleX(-1);
+            right: 0;
+          }
+
+          .label {
+            justify-content: flex-end;
+          }
+        }
+
+        &.positive {
+          border-left: none;
+          border-bottom-left-radius: 0;
+          border-top-left-radius: 0;
+        }
+      }
+    }
+  }
 }
 
 /* ------------------------------ */


### PR DESCRIPTION
Adds a flag property (in Special Traits) which can enable a new meter on the character sheet, displayed beneath Hit Dice. This meter goes from -5 to 5.

Closes #184.