### PR TITLE
[#189] Fix sheet race condition

### DIFF
--- a/scripts/modules/data/crafting.mjs
+++ b/scripts/modules/data/crafting.mjs
@@ -400,7 +400,8 @@ export class Crafting {
     const div = document.createElement("DIV");
     div.innerHTML = await renderTemplate(template, {...buttons, active: active});
     div.querySelectorAll("[data-action]").forEach(n => n.addEventListener("click", Crafting._onClickCraft.bind(sheet)));
-    html.querySelector(".tab-body").append(...div.childNodes);
+    const body = html.querySelector(".tab-body");
+    if (!body.querySelector(".tab.mythacri")) body.insertAdjacentElement("beforeend", div.firstElementChild);
   }
 
   /**


### PR DESCRIPTION
Closes #189.

If the sheet was rendered twice in rapid succession, the tab could be injected twice. This would only happen the first time the sheet is opened since the handlebars template was not retrieved and cached yet.

This adds an additional check for whether the injected element already exists.