### PR TITLE
Remove unneeded settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,5 +43,5 @@
     "source.fixAll.eslint": "always"
   },
   "eslint.enable": true,
-  "eslint.validate": ["javascript", "handlebars", "html"]
+  "eslint.validate": ["javascript"]
 }

--- a/languages/en.json
+++ b/languages/en.json
@@ -353,8 +353,6 @@
         "None": "{name} takes a full rest."
       }
     },
-    "SettingsFoldersPartyActors": "Party Actors Folder",
-    "SettingsFoldersPartyActorsHint": "The Actor folder that contains all of the party's assigned actors.",
     "SettingsIdentifiers": "Identifiers Menu",
     "SettingsIdentifiersHint": "Change various ids and identifiers.",
     "SettingsIdentifiersLabel": "Identifiers",
@@ -362,8 +360,6 @@
     "SettingsPacksCraftingRecipesHint": "The compendium pack that contains all crafting recipes.",
     "SettingsPacksCraftingResources": "Crafting Resources Pack",
     "SettingsPacksCraftingResourcesHint": "The compendium pack that contains all crafting resources.",
-    "SettingsParty": "Party Actor",
-    "SettingsPartyHint": "The id of the Group actor that contains the party.",
     "SettingsPathsSoundboard": "Soundboard File Path",
     "SettingsPathsSoundboardHint": "The data path to the folder that contains sound files for the soundboard application.",
     "Soundboard": "Soundboard",

--- a/scripts/modules/applications/crafting-application.mjs
+++ b/scripts/modules/applications/crafting-application.mjs
@@ -179,7 +179,7 @@ export default class CraftingApplication extends Application {
    * @returns {Promise<object[]>}     Compendium index entries.
    */
   async getAvailableRecipes() {
-    const pack = game.settings.get(MODULE.ID, "identifiers").packs.craftingRecipes;
+    const pack = game.packs.get(game.settings.get(MODULE.ID, "identifiers").packs.craftingRecipes);
     if (!pack) throw new Error("There is no valid crafting recipes compendium in the settings.");
 
     return (await pack.getIndex({

--- a/scripts/modules/applications/recipe-sheet.mjs
+++ b/scripts/modules/applications/recipe-sheet.mjs
@@ -222,16 +222,14 @@ export default class RecipeSheet extends dnd5e.applications.item.ItemSheet5e {
    * @returns {Actor5e[][]}     Array of arrays of learned, learners, and unavailable.
    */
   getLearners() {
-    const folder = game.settings.get(MODULE.ID, "identifiers").folders.partyActors;
+    const members = game.settings.get("dnd5e", "primaryParty").actor?.system.members.map(m => m.actor) ?? [];
     const parts = [[], [], []];
-    if (!folder) return parts;
-
-    for (const actor of folder.contents) {
+    for (const actor of members) {
+      if (!actor) continue;
       if (this.document.system.knowsRecipe(actor)) parts[0].push(actor);
       else if (this.document.system.canLearnRecipe(actor)) parts[1].push(actor);
       else parts[2].push(actor);
     }
-
     return parts;
   }
 }

--- a/scripts/modules/applications/resource-populator.mjs
+++ b/scripts/modules/applications/resource-populator.mjs
@@ -80,7 +80,8 @@ async function populate(actor) {
       if (!formula || !Roll.validate(formula)) model.updateSource({[`formulas.${k}`]: "1d2"});
     }
 
-    const pack = game.settings.get(MODULE.ID, "identifiers").packs.craftingResources;
+    const pack = game.packs.get(game.settings.get(MODULE.ID, "identifiers").packs.craftingResources);
+    if (!pack) throw new Error("There is no valid Crafting Resources compendium configured in the settings.");
     const items = await pack.getDocuments({
       type: "loot",
       flags: {

--- a/scripts/modules/data/transfer.mjs
+++ b/scripts/modules/data/transfer.mjs
@@ -114,7 +114,7 @@ async function promptTransfer(item) {
     return;
   }
 
-  const party = game.settings.get(MODULE.ID, "identifiers").party;
+  const party = game.settings.get("dnd5e", "primaryParty").actor;
   if (party?.type !== "group") {
     ui.notifications.error("MYTHACRI.TRANSFER.Warning.Party", {localize: true});
     return;

--- a/templates/settings-identifiers.hbs
+++ b/templates/settings-identifiers.hbs
@@ -1,50 +1,8 @@
 <div class="standard-form">
   <fieldset>
-    <div class="form-group">
-      <label>{{localize "MYTHACRI.SettingsPacksCraftingResources"}}</label>
-      <div class="form-fields">
-        <select name="packs.craftingResources">
-          {{selectOptions options.packs selected=source.packs.craftingResources sort=true blank="-"}}
-        </select>
-      </div>
-      <p class="hint">{{localize "MYTHACRI.SettingsPacksCraftingResourcesHint"}}</p>
-    </div>
-
-    <div class="form-group">
-      <label>{{localize "MYTHACRI.SettingsPacksCraftingRecipes"}}</label>
-      <div class="form-fields">
-        <select name="packs.craftingRecipes">
-          {{selectOptions options.packs selected=source.packs.craftingRecipes sort=true blank="-"}}
-        </select>
-      </div>
-      <p class="hint">{{localize "MYTHACRI.SettingsPacksCraftingRecipesHint"}}</p>
-    </div>
-
-    <div class="form-group">
-      <label>{{localize "MYTHACRI.SettingsFoldersPartyActors"}}</label>
-      <div class="form-fields">
-        <select name="folders.partyActors">
-          {{selectOptions options.folders selected=source.folders.partyActors sort=true blank="-"}}
-        </select>
-      </div>
-      <p class="hint">{{localize "MYTHACRI.SettingsFoldersPartyActorsHint"}}</p>
-    </div>
-
-    <div class="form-group">
-      <label>{{localize "MYTHACRI.SettingsPathsSoundboard"}}</label>
-      <div class="form-fields">
-        <input type="text" name="paths.soundboard" value="{{source.paths.soundboard}}">
-      </div>
-      <p class="hint">{{localize "MYTHACRI.SettingsPathsSoundboardHint"}}</p>
-    </div>
-
-    <div class="form-group">
-      <label>{{localize "MYTHACRI.SettingsParty"}}</label>
-      <div class="form-fields">
-        <input type="text" name="party" value="{{source.party}}">
-      </div>
-      <p class="hint">{{localize "MYTHACRI.SettingsPartyHint"}}</p>
-    </div>
+    {{#each fields}}
+    {{formGroup field value=value localize=true choices=choices}}
+    {{/each}}
   </fieldset>
 
   <button type="submit">


### PR DESCRIPTION
Simplifies the "Identifiers" settings menu, removing no longer needed stuff.

- The "Party Id" setting has been removed, instead the GM is required to configure a Primary Party (which is a standard system feature added in v3.0.0).
- The "Party Folder" setting, which stored the id for the folder where the party members were kept, has been removed, as this can be derived from the Primary Party group actor.