### PR TITLE
[#223] Optimize crafting UI slightly. Switch to target name.

### DIFF
--- a/templates/parts/crafting-recipe.hbs
+++ b/templates/parts/crafting-recipe.hbs
@@ -1,5 +1,5 @@
 <div class="{{cssClass}}" data-uuid="{{recipe.uuid}}" data-action="show" data-name="{{target.name}}">
-  <span class="label">{{recipe.name}}</span>
+  <span class="label">{{target.name}}</span>
   <span class="basic">{{#if isBasic}}{{localize "MYTHACRI.CRAFTING.SHEET.Basic"}}{{/if}}</span>
   <span class="target">
     <img src="{{target.img}}" data-tooltip="{{tooltip}}" data-tooltip-class="{{tooltipClass}}">


### PR DESCRIPTION
Closes #223.

This is entirely untested. I don't have an environment for testing crafting at all.

What this should do is load the indices of recipes when the game is fully ready rather than each time the crafting UI is rendered. This results in one data preparation method being able to be entirely synchronous rather than async.

Also changed the displayed name of recipes to instead be the crafted item's name (as requested in #223).